### PR TITLE
Add Edition handling

### DIFF
--- a/src/main/scala/com/gu/openplatform/contentapi/model/Model.scala
+++ b/src/main/scala/com/gu/openplatform/contentapi/model/Model.scala
@@ -227,6 +227,32 @@ case class Tag(
   def tagType = `type`
 }
 
+case class Edition(
+        /**
+         * The path of the edition, e.g. 'au/business'
+         */
+        id: String,
+
+        /**
+          * The edition code, e.g. 'uk' or 'default'.
+          */
+        code: String,
+
+        /**
+         * Short description of the edition
+         */
+        webTitle: String,
+
+        /**
+         * Edition URL for the main Guardian website
+         */
+        webUrl: String,
+
+        /**
+         * Path from which the edition is available in the Content API
+         */
+        apiUrl: String
+        )
 
 case class Section(
         /**

--- a/src/main/scala/com/gu/openplatform/contentapi/model/Responses.scala
+++ b/src/main/scala/com/gu/openplatform/contentapi/model/Responses.scala
@@ -72,6 +72,7 @@ case class ItemResponse(
         pages: Option[Int],
         orderBy: Option[String],
         tag: Option[Tag],
+        edition: Option[Edition],
         section: Option[Section],
         content: Option[Content],
         results: List[Content],


### PR DESCRIPTION
Adds  Edition handling for section item requests.

For example, I can make the following request:

```
import com.gu.openplatform.contentapi.Api
Api.item.itemId("business").response.edition
```

Which will return an Edition case class which looks like:

```
edition: {
  id: au/business
  code: au
  webTitle: Business
  webUrl: ..
  apiUrl: ..
}
```

This PR is related to https://github.com/guardian/content-api/pull/189 . But note, we can release this beforehand as calling `.edition` returns an Option - so the client will just get a `None` if no edition is found.

ps. ignore the incorrect chat in my last commit. You can access `section` and `edition` information by calling `.response` first.
