### PR TITLE
Add editions for sections

### DIFF
--- a/src/main/scala/com/gu/openplatform/contentapi/model/Model.scala
+++ b/src/main/scala/com/gu/openplatform/contentapi/model/Model.scala
@@ -284,7 +284,7 @@ case class Section(
         /**
          * List of available editions for this section
          */
-         editions: List[Edition]
+        editions: List[Edition]
         )
 
 case class Folder(


### PR DESCRIPTION
This PR complements https://github.com/guardian/content-api/pull/190 by enabling access to the list of editions we will shortly include with sections.

To access this editions information, for example, do:

```
Api.sections foreach { section => println(section.editions) }
```

or, for an individual section:

```
Api.item.itemId("business").response.section map { _.editions } getOrElse Nil
```

(Section is returned as an Option for item requests so we have to map over it.)
