### PR TITLE
Add new elements format

### DIFF
--- a/src/main/scala/com/gu/openplatform/contentapi/model/Model.scala
+++ b/src/main/scala/com/gu/openplatform/contentapi/model/Model.scala
@@ -103,7 +103,7 @@ case class Content(
         /**
          * New representation to elements (assets lists) only returns if show-elements("all") or show-elements("image") is specified
          */
-        elements: Option[Map[String, Element]],
+        elements: Option[List[Element]],
 
         /**
          * List of snippets that matched the requested query parameters.

--- a/src/test/resources/com/gu/openplatform/contentapi/parser/search-internal.json
+++ b/src/test/resources/com/gu/openplatform/contentapi/parser/search-internal.json
@@ -1,98 +1,100 @@
 {
-  "response":{
-    "status":"ok",
-    "userTier":"internal",
-    "total":1,
-    "startIndex":1,
-    "pageSize":2,
-    "currentPage":1,
-    "pages":1,
-    "orderBy":"newest",
-    "results":[{
-      "id":"music/picture/2010/aug/25/georgemichael-ukcrime",
-      "sectionId":"music",
-      "sectionName":"Music",
-      "webPublicationDate":"2010-08-25T11:08:53+01:00",
-      "webTitle":"Eyewitness: Wham! rap",
-      "webUrl":"http://www.guardian.co.uk/music/picture/2010/aug/25/georgemichael-ukcrime",
-      "apiUrl":"http://content.guardianapis.com/music/picture/2010/aug/25/georgemichael-ukcrime",
-      "factboxes":[{
-        "type":"photography-tip",
-        "fields":{
-          "proTip":"By using auto-focus, continuous shooting mode and holding his camera above the crowd, the photographer has managed to capture the scene"
-        }
-      }],
-      "mediaAssets":[{
-        "type":"picture",
-        "rel":"body",
-        "index":1,
-        "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/8/25/1282722354152/george-michael-appears-in-003.jpg",
-        "fields":{
-          "source":"Getty Images",
-          "photographer":"Peter Macdiarmid",
-          "height":"519",
-          "credit":"Peter Macdiarmid/Getty Images",
-          "altText":"george michael appears in court charged with driving offences",
-          "caption":"Singer George Michael leaves  Highbury magistrates court surrounded by press and police. Michael pleaded guilty to driving under the influence of drugs and possessing cannabis after he crashed his car into a  shop in London. The singer has been warned that he may face a custodial sentence after a previous similar offence",
-          "width":"780"
-        }
-      },{
-        "type":"picture",
-        "rel":"big-picture",
-        "index":1,
-        "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/8/25/1282722355694/george-michael-appears-in-004.jpg",
-        "fields":{
-          "source":"Getty Images",
-          "photographer":"Peter Macdiarmid",
-          "height":"768",
-          "credit":"Peter Macdiarmid/Getty Images",
-          "altText":"george michael appears in court charged with driving offences",
-          "caption":"Singer George Michael leaves  Highbury magistrates court surrounded by press and police. Michael pleaded guilty to driving under the influence of drugs and possessing cannabis after he crashed his car into a  shop in London. The singer has been warned that he may face a custodial sentence after a previous similar offence",
-          "width":"1024"
-        }
-      }],
-      "elements":{
-           "gu-image-1234": {
-                "id":"gu-image-1234",
-                "relation":"main",
-                "type":"image",
-                "assets":[
+    "response": {
+        "status": "ok",
+        "userTier": "internal",
+        "total": 1,
+        "startIndex": 1,
+        "pageSize": 2,
+        "currentPage": 1,
+        "pages": 1,
+        "orderBy": "newest",
+        "results": [
+            {
+                "id": "music/picture/2010/aug/25/georgemichael-ukcrime",
+                "sectionId": "music",
+                "sectionName": "Music",
+                "webPublicationDate": "2010-08-25T11:08:53+01:00",
+                "webTitle": "Eyewitness: Wham! rap",
+                "webUrl": "http://www.guardian.co.uk/music/picture/2010/aug/25/georgemichael-ukcrime",
+                "apiUrl": "http://content.guardianapis.com/music/picture/2010/aug/25/georgemichael-ukcrime",
+                "factboxes": [
                     {
-                        "type":"image",
-                        "mimeType":"image/jpeg",
-                        "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/8/25/1282722355694/george-michael-appears-in-004.jpg",
-                        "typeData":{
-                            "source":"Getty Images",
-                            "photographer":"Peter Macdiarmid",
-                            "altText":"george michael appears in court charged with driving offences",
-                            "height":"768",
-                            "credit":"Peter Macdiarmid/Getty Images",
-                            "caption":"Singer George Michael leaves  Highbury magistrates court surrounded by press and police. Michael pleaded guilty to driving under the influence of drugs and possessing cannabis after he crashed his car into a  shop in London. The singer has been warned that he may face a custodial sentence after a previous similar offence",
-                            "width":"1024"
+                        "type": "photography-tip",
+                        "fields": {
+                            "proTip": "By using auto-focus, continuous shooting mode and holding his camera above the crowd, the photographer has managed to capture the scene"
                         }
-                     },
-                     {
-                        "type":"image",
-                        "mimeType":"image/jpeg",
-                        "file":"http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/8/25/1282722354152/george-michael-appears-in-003.jpg",
-                        "typeData":{
-                            "source":"Getty Images",
-                            "photographer":"Peter Macdiarmid",
-                            "altText":"george michael appears in court charged with driving offences",
-                            "height":"519",
-                            "credit":"Peter Macdiarmid/Getty Images",
-                            "caption":"Singer George Michael leaves  Highbury magistrates court surrounded by press and police. Michael pleaded guilty to driving under the influence of drugs and possessing cannabis after he crashed his car into a  shop in London. The singer has been warned that he may face a custodial sentence after a previous similar offence",
-                            "width":"780"
-                        }
-                     }
-                     ]
                     }
-                }
+                ],
+                "mediaAssets": [
+                    {
+                        "type": "picture",
+                        "rel": "body",
+                        "index": 1,
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/8/25/1282722354152/george-michael-appears-in-003.jpg",
+                        "fields": {
+                            "source": "Getty Images",
+                            "photographer": "Peter Macdiarmid",
+                            "height": "519",
+                            "credit": "Peter Macdiarmid/Getty Images",
+                            "altText": "george michael appears in court charged with driving offences",
+                            "caption": "Singer George Michael leaves  Highbury magistrates court surrounded by press and police. Michael pleaded guilty to driving under the influence of drugs and possessing cannabis after he crashed his car into a  shop in London. The singer has been warned that he may face a custodial sentence after a previous similar offence",
+                            "width": "780"
+                        }
+                    },
+                    {
+                        "type": "picture",
+                        "rel": "big-picture",
+                        "index": 1,
+                        "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/8/25/1282722355694/george-michael-appears-in-004.jpg",
+                        "fields": {
+                            "source": "Getty Images",
+                            "photographer": "Peter Macdiarmid",
+                            "height": "768",
+                            "credit": "Peter Macdiarmid/Getty Images",
+                            "altText": "george michael appears in court charged with driving offences",
+                            "caption": "Singer George Michael leaves  Highbury magistrates court surrounded by press and police. Michael pleaded guilty to driving under the influence of drugs and possessing cannabis after he crashed his car into a  shop in London. The singer has been warned that he may face a custodial sentence after a previous similar offence",
+                            "width": "1024"
+                        }
+                    }
+                ],
+                "elements": [
+                    {
+                        "id": "gu-image-1234",
+                        "relation": "main",
+                        "type": "image",
+                        "assets": [
+                            {
+                                "type": "image",
+                                "mimeType": "image/jpeg",
+                                "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/8/25/1282722355694/george-michael-appears-in-004.jpg",
+                                "typeData": {
+                                    "source": "Getty Images",
+                                    "photographer": "Peter Macdiarmid",
+                                    "altText": "george michael appears in court charged with driving offences",
+                                    "height": "768",
+                                    "credit": "Peter Macdiarmid/Getty Images",
+                                    "caption": "Singer George Michael leaves  Highbury magistrates court surrounded by press and police. Michael pleaded guilty to driving under the influence of drugs and possessing cannabis after he crashed his car into a  shop in London. The singer has been warned that he may face a custodial sentence after a previous similar offence",
+                                    "width": "1024"
+                                }
+                            },
+                            {
+                                "type": "image",
+                                "mimeType": "image/jpeg",
+                                "file": "http://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/8/25/1282722354152/george-michael-appears-in-003.jpg",
+                                "typeData": {
+                                    "source": "Getty Images",
+                                    "photographer": "Peter Macdiarmid",
+                                    "altText": "george michael appears in court charged with driving offences",
+                                    "height": "519",
+                                    "credit": "Peter Macdiarmid/Getty Images",
+                                    "caption": "Singer George Michael leaves  Highbury magistrates court surrounded by press and police. Michael pleaded guilty to driving under the influence of drugs and possessing cannabis after he crashed his car into a  shop in London. The singer has been warned that he may face a custodial sentence after a previous similar offence",
+                                    "width": "780"
+                                }
+                            }
+                        ]
+                    }
+                ]
             }
         ]
-  }
+    }
 }
-
-
-
-

--- a/src/test/scala/com/gu/openplatform/contentapi/parser/SearchJsonParserTest.scala
+++ b/src/test/scala/com/gu/openplatform/contentapi/parser/SearchJsonParserTest.scala
@@ -142,7 +142,7 @@ class SearchJsonParserTest extends FlatSpec with ShouldMatchers {
 
     val elements = elementAssets.get
     elements.size should be(1)
-    val element = elements("gu-image-1234")
+    val element = elements.head
 
 
     element.id should be("gu-image-1234")


### PR DESCRIPTION
Update client to read new elements format (elements as a JSON array rather than JSON object).

Note, this can be merged in but shouldn't be used for a formal release until the elements changes have gone live. See: https://github.com/guardian/content-api/pull/245 .
