### PR TITLE
Make api key a val

### DIFF
--- a/src/main/scala/com/gu/openplatform/contentapi/Api.scala
+++ b/src/main/scala/com/gu/openplatform/contentapi/Api.scala
@@ -23,7 +23,7 @@ trait Api[F[_]] extends Http[F] with JsonParser {
   implicit def M: Monad[F]
 
   val targetUrl = "http://content.guardianapis.com"
-  var apiKey: Option[String] = None
+  val apiKey: Option[String] = None
 
   def sections = new SectionsQuery
   def tags = new TagsQuery

--- a/src/test/scala/com/gu/openplatform/contentapi/ApiTest.scala
+++ b/src/test/scala/com/gu/openplatform/contentapi/ApiTest.scala
@@ -3,20 +3,18 @@ package com.gu.openplatform.contentapi
 import org.scalatest.matchers.ShouldMatchers
 import org.scalatest.FunSuite
 import org.joda.time.DateTime
+import com.gu.openplatform.contentapi.connection.JavaNetSyncHttp
 
 
 class ApiTest extends FunSuite with ShouldMatchers {
   test("should correctly add api key if present") {
-    try {
-      Api.apiKey = None
-      Api.search.parameters.get("api-key") should be (None)
+    Api.search.parameters.get("api-key") should be (None)
 
-      Api.apiKey = Some("abcd")
-      Api.search.parameters.get("api-key") should be (Some("abcd"))
-
-    } finally {
-      Api.apiKey = None
+    object ApiWithKey extends SyncApi with JavaNetSyncHttp {
+      override val apiKey = Some("abcd")
     }
+
+    ApiWithKey.search.parameters.get("api-key") should be (Some("abcd"))
   }
 
   test("should add custom parameters") {


### PR DESCRIPTION
There's no reason `apiKey` should be a `var` here. Let's do the less confusing thing.
