### PR TITLE
Add tag description as optional string field

### DIFF
--- a/src/main/scala/com/gu/openplatform/contentapi/model/Model.scala
+++ b/src/main/scala/com/gu/openplatform/contentapi/model/Model.scala
@@ -207,6 +207,14 @@ case class Tag(
     references: List[Reference] = Nil,
 
     /**
+     * A tag *may* have a description field.
+     *
+     * Contributor tags never have a description field. They may
+     * instead have a 'bio' field.
+     */
+    description: Option[String] = None,
+
+    /**
     * If this tag is a contributor then we *may* have a small bio
     * for the contributor.
     *


### PR DESCRIPTION
Allows client to pick up new 'description' field for tags.

For more info, see: https://github.com/guardian/content-api/pull/568
