### PR TITLE
Perf mkstring improvement

### DIFF
--- a/src/main/scala/com/gu/openplatform/contentapi/connection/Http.scala
+++ b/src/main/scala/com/gu/openplatform/contentapi/connection/Http.scala
@@ -87,7 +87,12 @@ trait JavaNetSyncHttp extends SyncHttp {
     headers.foreach { case (k, v) => connection.setRequestProperty(k, v) }
 
     val src = Source.fromInputStream(connection.getInputStream)
-    val responseBody = src.mkString
+    /*
+     * Starting from Scala 2.10 Source.mkString is very slow has it will used an iterator for each char.
+     * See https://issues.scala-lang.org/browse/SI-7356 for details.
+     * This has been fixed in scala 2.11.
+     */
+    val responseBody = src.getLines.mkString
     src.close
 
     new HttpResponse(responseBody, connection.getResponseCode, connection.getResponseMessage)


### PR DESCRIPTION
While [moving sitemap to v2](https://github.com/guardian/sitemap/pull/9) I found that the content-api client using scala `2.10` was 10 times slower than a previous version using scala `2.9` when launching in GAE context.

I tracked down the problem and found the following differences:
- `2.9` - `scala.io.Source.mkString` calls  `scala.io.Source.foreach` which is using an iterator which calls `next` and `hasNext`.

![screen shot 2014-05-14 at 07 21 01](https://cloud.githubusercontent.com/assets/615085/2968928/4387203a-db47-11e3-896a-4a561ecfbd2b.png)
- `2.10` -  `scala.io.Source.mkString` is doing the same, but with a much more larger `next` and `hasNext` invocations number.

![screen shot 2014-05-14 at 07 21 38](https://cloud.githubusercontent.com/assets/615085/2968929/43874902-db47-11e3-9d07-24171cdf9618.png)

So this is linked to a scala internal change, and performance bottleneck has indeed been [noticed and reported](https://issues.scala-lang.org/browse/SI-7356).
`scala.io.Source.mkString` has been [improved](https://github.com/scala/scala/pull/2929/files#diff-ea05b75bda49ff3b4ace3c2a256bde86R89) in scala `2.11` to fix the problem, but the workaround proposed in this pull request works for both `2.10` and `2.11`.
