### PR TITLE
Add first and last name to tag

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/model/Model.scala
+++ b/src/main/scala/com.gu.contentapi.client/model/Model.scala
@@ -238,7 +238,14 @@ case class Tag(
     /**
     * If this tag is a series it could be a podcast.
     */
-    podcast: Option[Podcast] = None)
+    podcast: Option[Podcast] = None,
+
+    /**
+     * If the tag is a contributor it may have a first name and last name.
+     */
+    firstName: Option[String] = None,
+
+    lastName: Option[String] = None)
 
 case class Edition(
 


### PR DESCRIPTION
If the tag is a contributor tag it may have a first name and last name attached.

(This is currently derived from the sort key but in the future will use better data that comes from Composer.)

CC @mchv 
