### PR TITLE
Separates queries from their execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Content API Scala Client
 A Scala client for the Guardian's [Content API] (http://explorer.content.guardianapis.com/).
 
 
-Usage
------
+## Setup
 
 Add the following line to your SBT build definition, and set the version number to be the latest from the [releases page] (https://github.com/guardian/content-api-scala-client/releases):
 
@@ -16,29 +15,43 @@ libraryDependencies += "com.gu" %% "content-api-client" % "x.y"
 If you don't have an API key, go to [guardian.mashery.com] (http://guardian.mashery.com/) to get one. You will then need to create a new instance of the client and set the key:
 
 ```scala
-val guardian = new GuardianContentClient("your-api-key")
+val client = new GuardianContentClient("your-api-key")
 ```
 
-There are then four different types of request that can be made: for a single item, or to filter through content, tags, or sections.
+## Usage
+
+There are then four different types of query that can be performed: for a single item, or to filter through content, tags, or sections. You make a request of the Content API by creating a query and then using the client to get a response, which will come back in a `Future`.
+
+Use these imports for the following code samples (substituting your own execution context for real code):
+
+```scala
+import com.gu.contentapi.client.GuardianContentClient
+import com.gu.contentapi.client.model._
+import org.joda.time.DateTime
+import scala.concurrent.ExecutionContext.Implicits.global
+```
 
 ### Single item
 
 Every item on http://www.theguardian.com/ can be retrieved on the same path at http://content.guardianapis.com/. They can be either content items, tags, or sections. For example:
 
 ```scala
-// print the web title of a content item
-guardian.item.itemId("commentisfree/2013/jan/16/vegans-stomach-unpalatable-truth-quinoa").response map { response =>
-  println(response.content.get.webTitle)
+// query for a single content item and print its web title
+val itemQuery = ItemQuery().itemId("commentisfree/2013/jan/16/vegans-stomach-unpalatable-truth-quinoa")
+client.getResponse(itemQuery).foreach { itemResponse =>
+  println(itemResponse.content.get.webTitle)
 }
 
-// print the web title of a tag
-guardian.item.itemId("travel/france").response map { response =>
-  println(response.tag.get.webTitle)
+// print web title for a tag
+val tagQuery = ItemQuery().itemId("music/metal")
+client.getResponse(tagQuery).foreach { tagResponse =>
+  println(tagResponse.content.get.webTitle)
 }
 
-// print the web title of a section
-guardian.item.itemId("environment").response map { response =>
-  println(response.section.get.webTitle)
+// print web title for a section
+val sectionQuery = ItemQuery().itemId("environment")
+client.getResponse(sectionQuery).foreach { sectionResponse =>
+  println(sectionResponse.content.get.webTitle)
 }
 ```
 
@@ -46,44 +59,30 @@ Individual content items contain information not available from the `/search` en
 
 ```scala
 // print the body of a given content item
-guardian.item
-    .itemId("politics/2014/sep/15/putin-bad-as-stalin-former-defence-secretary")
-    .showFields("body")
-    .response map { response =>
+val itemBodyQuery = ItemQuery()
+  .itemId("politics/2014/sep/15/putin-bad-as-stalin-former-defence-secretary")
+  .showFields("body")
+client.getResponse(itemBodyQuery) map { response =>
   for (fields <- response.content.get.fields) println(fields("body"))
 }
 
 // print the web title of every tag a content item has
-guardian.item
-    .itemId("environment/2014/sep/14/invest-in-monitoring-and-tagging-sharks-to-prevent-attacks")
-    .showTags("all")
-    .response map { response =>
+val itemWebTitleQuery = ItemQuery()
+  .itemId("environment/2014/sep/14/invest-in-monitoring-and-tagging-sharks-to-prevent-attacks")
+  .showTags("all")
+client.getResponse(itemWebTitleQuery) map { response =>
   for (tag <- response.content.get.tags) println(tag.webTitle)
 }
 
-// print the web titles of each content item in the most recent story package
-for (searchResponse <- guardian.search.showFields("hasStoryPackage").response)
-yield for (firstItem <- searchResponse.results.find(_.fields.get("hasStoryPackage") == "true"))
-yield for (itemResponse <- guardian.item.itemId(firstItem.id).showStoryPackage().response)
-yield for (result <- itemResponse.storyPackage) {
-  println(result.webTitle)
-}
-```
-
-Individual tags:
-
-```scala
 // print the web title of each content item in the editor's picks for the film tag
-guardian.item.itemId("film/film").showEditorsPicks().response map { response =>
+val editorsFilmsQuery = ItemQuery().itemId("film/film").showEditorsPicks()
+client.getResponse(editorsFilmsQuery) map { response =>
   for (result <- response.editorsPicks) println(result.webTitle)
 }
-```
 
-Individual sections:
-
-```scala
 // print the web title of the most viewed content items from the world section
-guardian.item.itemId("world").showMostViewed().response map { response =>
+val mostViewedTitleQuery = ItemQuery().itemId("world").showMostViewed()
+client.getResponse(mostViewedTitleQuery) map { response =>
   for (result <- response.mostViewed) println(result.webTitle)
 }
 ```
@@ -94,33 +93,38 @@ Filtering or searching for multiple content items happens at http://content.guar
 
 ```scala
 // print the total number of content items
-guardian.search.response map { response =>
+val allContentSearch = SearchQuery()
+client.getResponse(allContentSearch) map { response =>
   println(response.total)
 }
 
-// print the web titles of the 10 most recent content items
-guardian.search.response map { response =>
+// print the web titles of the 15 most recent content items
+val lastTenSearch = SearchQuery().pageSize(15)
+client.getResponse(lastTenSearch) map { response =>
   for (result <- response.results) println(result.webTitle)
 }
 
 // print the web titles of the 10 most recent content items matching a search term
-guardian.search.q("cheese on toast").response map { response =>
+val toastSearch = SearchQuery().q("cheese on toast")
+client.getResponse(toastSearch) map { response =>
   for (result <- response.results) println(result.webTitle)
 }
 
-// print the web titles of the 10 most recent content items with certain tags
-guardian.search.tag("lifeandstyle/cheese,type/gallery").response map { response =>
+// print the web titles of the 10 (default page size) most recent content items with certain tags
+val tagSearch = SearchQuery().tag("lifeandstyle/cheese,type/gallery")
+client.getResponse(tagSearch) map { response =>
   for (result <- response.results) println(result.webTitle)
 }
 
 // print the web titles of the 10 most recent content items in the world section
-guardian.search.section("world").response map { response =>
+val sectionSearch = SearchQuery().section("world")
+client.getResponse(sectionSearch) map { response =>
   for (result <- response.results) println(result.webTitle)
 }
 
 // print the web titles of the last 10 content items published a week ago
-import org.joda.time.DateTime
-guardian.search.toDate(new DateTime().minusDays(7)).response map { response =>
+val timeSearch = SearchQuery().toDate(new DateTime().minusDays(7))
+client.getResponse(timeSearch) map { response =>
   for (result <- response.results) println(result.webTitle)
 }
 ```
@@ -131,28 +135,31 @@ Filtering or searching for multiple tags happens at http://content.guardianapis.
 
 ```scala
 // print the total number of tags
-guardian.tags.response map { response =>
+val allTagsQuery = TagsQuery()
+client.getResponse(allTagsQuery) map { response =>
   println(response.total)
 }
 
 // print the web titles of the first 50 tags
-guardian.tags.pageSize(50).response map { response =>
+val fiftyTagsQuery = TagsQuery().pageSize(50)
+client.getResponse(fiftyTagsQuery) map { response =>
   for (result <- response.results) println(result.webTitle)
 }
 
 // print the web titles and bios of the first 10 contributor tags which have them
-guardian.tags.tagType("contributor").response map { response =>
+val contributorTagsQuery = TagsQuery().tagType("contributor")
+client.getResponse(contributorTagsQuery) map { response =>
   for (result <- response.results.filter(_.bio.isDefined)) {
     println(result.webTitle + "\n" + result.bio.get + "\n")
   }
 }
 
 // print the web titles and numbers of the first 10 books tags with ISBNs
-guardian.tags
-    .section("books")
-    .referenceType("isbn")
-    .showReferences("isbn")
-    .response map { response =>
+val isbnTagsSearch = TagsQuery()
+  .section("books")
+  .referenceType("isbn")
+  .showReferences("isbn")
+client.getResponse(isbnTagsSearch) map { response =>
   for (result <- response.results) {
     println(result.webTitle + " -- " + result.references.head.id)
   }
@@ -165,18 +172,18 @@ Filtering or searching for multiple sections happens at http://content.guardiana
 
 ```scala
 // print the web title of each section
-guardian.sections.response map { response =>
+val allSectionsQuery = SectionsQuery()
+client.getResponse(allSectionsQuery) map { response =>
   for (result <- response.results) println(result.webTitle)
 }
 
 // print the web title of each section with 'network' in the title
-guardian.sections.q("network").response map { response =>
+val networkSectionsQuery = SectionsQuery().q("network")
+client.getResponse(networkSectionsQuery) map { response =>
   for (result <- response.results) println(result.webTitle)
 }
 ```
 
-
-Troubleshooting
----------------
+## Troubleshooting
 
 If you have any problems you can speak to other developers at the [Guardian API talk group] (http://groups.google.com/group/guardian-api-talk).

--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -76,6 +76,21 @@ trait ContentApiClientLogic {
     http(request, handler)
   }
 
+  def getResponse(itemQuery: ItemQuery): Future[ItemResponse] = {
+    val location = itemQuery.path.getOrElse(throw new Exception("No API URL provided to item query, ensure apiUrl/itemId is called"))
+    fetch(s"$targetUrl/$location", itemQuery.parameters) map JsonParser.parseItem
+  }
+  def getResponse(searchQuery: SearchQuery): Future[SearchResponse] =
+    fetch(s"$targetUrl/search", searchQuery.parameters) map JsonParser.parseSearch
+  def getResponse(tagsQuery: TagsQuery): Future[TagsResponse] =
+    fetch(s"$targetUrl/tags", tagsQuery.parameters) map JsonParser.parseTags
+  def getResponse(sectionsQuery: SectionsQuery): Future[SectionsResponse] =
+    fetch(s"$targetUrl/sections", sectionsQuery.parameters) map JsonParser.parseSections
+  def getResponse(collectionQuery: CollectionQuery): Future[CollectionResponse] = {
+    val location = collectionQuery.path.getOrElse(throw new Exception("No API URL provided to collection query, ensure apiUrl/collectionId is called"))
+    fetch(s"$targetUrl/collections/$location", collectionQuery.parameters) map JsonParser.parseCollection
+  }
+
   /**
    * Contains implicits to maintain `query.response` behaviour, along with
    * other methods that require a configured client
@@ -91,13 +106,11 @@ trait ContentApiClientLogic {
       def asResponse = response
     }
 
-
     implicit class SearchQueryResult(searchQuery: SearchQuery) {
       lazy val response: Future[SearchResponse] = getResponse(searchQuery)
       def asResponse = response
       def asContent = response.map(_.results)
     }
-
 
     implicit class TagsQueryResult(tagsQuery: TagsQuery) {
       lazy val response: Future[TagsResponse] = getResponse(tagsQuery)
@@ -105,13 +118,11 @@ trait ContentApiClientLogic {
       def asTags = response.map(_.results)
     }
 
-
     implicit class SectionsQueryResult(sectionsQuery: SectionsQuery) {
       lazy val response: Future[SectionsResponse] = getResponse(sectionsQuery)
       def asResponse = response
       def asSections = response.map(_.results)
     }
-
 
     implicit class CollectionQueryResult(collectionQuery: CollectionQuery) {
       def apiUrl(newContentPath: String): CollectionQuery = {
@@ -123,21 +134,6 @@ trait ContentApiClientLogic {
       def asResponse = response
       def asCollection = response.map(_.collection)
     }
-  }
-
-  def getResponse(itemQuery: ItemQuery): Future[ItemResponse] = {
-    val location = itemQuery.path.getOrElse(throw new Exception("No API URL provided to item query, ensure apiUrl/itemId is called"))
-    fetch(s"$targetUrl/$location", itemQuery.parameters) map JsonParser.parseItem
-  }
-  def getResponse(searchQuery: SearchQuery): Future[SearchResponse] =
-    fetch(s"$targetUrl/search", searchQuery.parameters) map JsonParser.parseSearch
-  def getResponse(tagsQuery: TagsQuery): Future[TagsResponse] =
-    fetch(s"$targetUrl/tags", tagsQuery.parameters) map JsonParser.parseTags
-  def getResponse(sectionsQuery: SectionsQuery): Future[SectionsResponse] =
-    fetch(s"$targetUrl/sections", sectionsQuery.parameters) map JsonParser.parseSections
-  def getResponse(collectionQuery: CollectionQuery): Future[CollectionResponse] = {
-    val location = collectionQuery.path.getOrElse(throw new Exception("No API URL provided to collection query, ensure apiUrl/collectionId is called"))
-    fetch(s"$targetUrl/collections/$location", collectionQuery.parameters) map JsonParser.parseCollection
   }
 }
 

--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -1,12 +1,14 @@
 package com.gu.contentapi.client
 
-import scala.concurrent.{Future, ExecutionContext}
 import java.net.URLEncoder
-import org.joda.time.format.ISODateTimeFormat
-import org.joda.time.ReadableInstant
-import dispatch.{Http, FunctionHandler}
-import com.gu.contentapi.client.parser.JsonParser
+
 import com.gu.contentapi.client.model._
+import com.gu.contentapi.client.parser.JsonParser
+import dispatch.{FunctionHandler, Http}
+import org.joda.time.ReadableInstant
+import org.joda.time.format.ISODateTimeFormat
+
+import scala.concurrent.{ExecutionContext, Future}
 
 case class GuardianContentApiError(httpStatus: Int, httpMessage: String) extends Exception(httpMessage)
 
@@ -34,200 +36,9 @@ trait ContentApiClientLogic {
   def sections = new SectionsQuery
   def collection = new CollectionQuery
 
-  case class ItemQuery(path: Option[String] = None, parameterHolder: Map[String, Parameter] = Map.empty)
-      extends KeyParameters[ItemQuery]
-      with EditionParameters[ItemQuery]
-      with ContentParameters[ItemQuery]
-      with ShowParameters[ItemQuery]
-      with ShowReferencesParameters[ItemQuery]
-      with ShowExtendedParameters[ItemQuery]
-      with PaginationParameters[ItemQuery]
-      with OrderingParameters[ItemQuery]
-      with FilterParameters[ItemQuery]
-      with FilterExtendedParameters[ItemQuery]
-      with FilterSearchParameters[ItemQuery] {
-
-    def apiUrl(newContentPath: String): ItemQuery = {
-      require(newContentPath startsWith targetUrl, "apiUrl expects a full URL, use itemId if you only have an ID")
-      copy(path = Some(newContentPath))
-    }
-
-    def itemId(contentId: String): ItemQuery = {
-      apiUrl(targetUrl + "/" + contentId)
-    }
-
-    lazy val response: Future[ItemResponse] = {
-      val location = path.getOrElse(throw new Exception("No API URL provided to item query, ensure withApiUrl is called"))
-      fetch(location, parameters) map JsonParser.parseItem
-    }
-
-    def withParameters(parameterMap: Map[String, Parameter]) = copy(path, parameterMap)
-
-  }
-
-  object ItemQuery {
-    implicit def asResponse(q: ItemQuery) = q.response
-  }
-
-  case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-      extends KeyParameters[SearchQuery]
-      with ContentParameters[SearchQuery]
-      with ShowParameters[SearchQuery]
-      with ShowReferencesParameters[SearchQuery]
-      with OrderingParameters[SearchQuery]
-      with PaginationParameters[SearchQuery]
-      with FilterParameters[SearchQuery]
-      with FilterExtendedParameters[SearchQuery]
-      with FilterSearchParameters[SearchQuery] {
-
-    lazy val response: Future[SearchResponse] = {
-      fetch(targetUrl + "/search", parameters) map JsonParser.parseSearch
-    }
-
-    def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
-
-  }
-
-  object SearchQuery {
-    implicit def asResponse(q: SearchQuery) = q.response
-    implicit def asContent(q: SearchQuery) = q.response.map(_.results)
-  }
-
-  case class TagsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-      extends KeyParameters[TagsQuery]
-      with ShowReferencesParameters[TagsQuery]
-      with PaginationParameters[TagsQuery]
-      with FilterParameters[TagsQuery]
-      with FilterTagParameters[TagsQuery]
-      with FilterSearchParameters[TagsQuery] {
-
-    lazy val response: Future[TagsResponse] = {
-      fetch(targetUrl + "/tags", parameters) map JsonParser.parseTags
-    }
-
-    def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
-
-  }
-
-  object TagsQuery {
-    implicit def asResponse(q: TagsQuery) = q.response
-    implicit def asTags(q: TagsQuery) = q.response.map(_.results)
-  }
-
-  case class SectionsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-      extends KeyParameters[SectionsQuery]
-      with FilterSearchParameters[SectionsQuery] {
-
-    lazy val response: Future[SectionsResponse] = {
-      fetch(targetUrl + "/sections", parameters) map JsonParser.parseSections
-    }
-
-    def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
-
-  }
-
-  object SectionsQuery {
-    implicit def asResponse(q: SectionsQuery) = q.response
-    implicit def asSections(q: SectionsQuery) = q.response.map(_.results)
-  }
-
-  case class CollectionQuery(path: Option[String] = None, parameterHolder: Map[String, Parameter] = Map.empty)
-      extends KeyParameters[CollectionQuery]
-      with ShowParameters[CollectionQuery]
-      with ShowReferencesParameters[CollectionQuery]
-      with FilterParameters[CollectionQuery]
-      with FilterExtendedParameters[CollectionQuery] {
-
-    def apiUrl(newContentPath: String): CollectionQuery = {
-      require(newContentPath startsWith targetUrl, "apiUrl expects a full URI: use collectionId if you only have an ID")
-      copy(path = Some(newContentPath))
-    }
-
-    def collectionId(collectionId: String): CollectionQuery = {
-      apiUrl(targetUrl + "/collections/" + collectionId)
-    }
-
-    lazy val response: Future[CollectionResponse] = {
-      val location = path.getOrElse(throw new Exception("No API URL provided to collection query, ensure withApiUrl is called"))
-      fetch(location, parameters) map JsonParser.parseCollection
-    }
-
-    def withParameters(parameterMap: Map[String, Parameter]) = copy(path, parameterMap)
-
-  }
-
-  object CollectionQuery {
-    implicit def asResponse(q: CollectionQuery) = q.response
-    implicit def asCollection(q: CollectionQuery) = q.response.map(_.collection)
-  }
-
-  trait KeyParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    override def parameters = super.parameters + ("api-key" -> apiKey)
-  }
-
-  trait ContentParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def contentSet = StringParameter("content-set")
-  }
-
-  trait EditionParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def edition = StringParameter("edition")
-  }
-
-  trait ShowParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def showFields = StringParameter("show-fields")
-    def showTags = StringParameter("show-tags")
-    def showElements = StringParameter("show-elements")
-    def showRights = StringParameter("show-rights")
-  }
-
-  trait ShowReferencesParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def showReferences = StringParameter("show-references")
-  }
-
-  trait ShowExtendedParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def showStoryPackage = BoolParameter("show-story-package")
-    def showRelated = BoolParameter("show-related")
-    def showMostViewed = BoolParameter("show-most-viewed")
-    def showEditorsPicks = BoolParameter("show-editors-picks")
-  }
-
-  trait PaginationParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def page = IntParameter("page")
-    def pageSize = IntParameter("page-size")
-  }
-
-  trait OrderingParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def orderBy = StringParameter("order-by")
-    def useDate = StringParameter("use-date")
-  }
-
-  trait FilterParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def section = StringParameter("section")
-    def reference = StringParameter("reference")
-    def referenceType = StringParameter("reference-type")
-    def productionOffice = StringParameter("production-office")
-  }
-
-  trait FilterExtendedParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def tag = StringParameter("tag")
-    def ids = StringParameter("ids")
-    def rights = StringParameter("rights")
-    def leadContent = StringParameter("lead-content")
-    def fromDate = DateParameter("from-date")
-    def toDate = DateParameter("to-date")
-  }
-
-  trait FilterTagParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def tagType = StringParameter("type")
-  }
-
-  trait FilterSearchParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-    def q = StringParameter("q")
-  }
-
   case class HttpResponse(body: String, statusCode: Int, statusMessage: String)
 
-  protected def fetch(location: String, parameters: Map[String, String]): Future[String] = {
+  protected[client] def url(location: String, parameters: Map[String, String]): String = {
     require(!location.contains('?'), "must not specify parameters in URL")
 
     def encodeParameter(p: Any): String = p match {
@@ -236,16 +47,19 @@ trait ContentApiClientLogic {
     }
 
     val queryString = {
-      val pairs = parameters map {
+      val pairs = (parameters + ("api-key" -> apiKey)) map {
         case (k, v) => k + "=" + encodeParameter(v)
       }
       pairs mkString "&"
     }
 
-    val url = location + "?" + queryString
+    location + "?" + queryString
+  }
+
+  protected def fetch(location: String, parameters: Map[String, String]): Future[String] = {
     val headers = Map("User-Agent" -> "scala-client", "Accept" -> "application/json")
 
-    for (response <- get(url, headers))
+    for (response <- get(url(location, parameters), headers))
     yield if (List(200, 302) contains response.statusCode) response.body
     else throw new GuardianContentApiError(response.statusCode, response.statusMessage)
   }
@@ -260,6 +74,85 @@ trait ContentApiClientLogic {
     http(request, handler)
   }
 
+  /**
+   * Contains implicits to maintain `query.response` behaviour, along with
+   * other methods that require a configured client
+   */
+  object Results {
+    implicit class ItemQueryResult(itemQuery: ItemQuery) extends ItemQuery {
+      def apiUrl(newContentPath: String): ItemQuery = {
+        require(newContentPath startsWith targetUrl, "apiUrl expects a full URL, use itemId if you only have an ID")
+        itemQuery.copy(path = Some(newContentPath))
+      }
+
+      def itemId(contentId: String): ItemQuery = {
+        apiUrl(targetUrl + "/" + contentId)
+      }
+
+      lazy val response: Future[ItemResponse] = {
+        val location = itemQuery.path.getOrElse(throw new Exception("No API URL provided to item query, ensure withApiUrl is called"))
+        fetch(location, itemQuery.parameters) map JsonParser.parseItem
+      }
+
+      def asResponse = response
+    }
+
+
+    implicit class SearchQueryResult(searchQuery: SearchQuery) {
+      lazy val response: Future[SearchResponse] = {
+        fetch(targetUrl + "/search", searchQuery.parameters) map JsonParser.parseSearch
+      }
+
+      def asResponse = response
+      def asContent = response.map(_.results)
+    }
+
+
+    implicit class TagsQueryResult(tagsQuery: TagsQuery) {
+      lazy val response: Future[TagsResponse] = {
+        fetch(targetUrl + "/tags", tagsQuery.parameters) map JsonParser.parseTags
+      }
+
+      def asResponse = response
+      def asTags = response.map(_.results)
+    }
+
+
+    implicit class SectionsQueryResult(sectionsQuery: SectionsQuery) {
+      lazy val response: Future[SectionsResponse] = {
+        fetch(targetUrl + "/sections", sectionsQuery.parameters) map JsonParser.parseSections
+      }
+
+      def asResponse = response
+      def asSections = response.map(_.results)
+    }
+
+
+    implicit class CollectionQueryResult(collectionQuery: CollectionQuery) {
+      def apiUrl(newContentPath: String): CollectionQuery = {
+        require(newContentPath startsWith targetUrl, "apiUrl expects a full URI: use collectionId if you only have an ID")
+        collectionQuery.copy(path = Some(newContentPath))
+      }
+
+      def collectionId(collectionId: String): CollectionQuery = {
+        apiUrl(targetUrl + "/collections/" + collectionId)
+      }
+
+      lazy val response: Future[CollectionResponse] = {
+        val location = collectionQuery.path.getOrElse(throw new Exception("No API URL provided to collection query, ensure withApiUrl is called"))
+        fetch(location, collectionQuery.parameters) map JsonParser.parseCollection
+      }
+
+      def asResponse = response
+      def asCollection = response.map(_.collection)
+    }
+  }
+
+  def executeItemQuery(itemQuery: ItemQuery): Future[ItemResponse] = Results.ItemQueryResult(itemQuery).response
+  def executeSearchQuery(searchQuery: SearchQuery): Future[SearchResponse] = Results.SearchQueryResult(searchQuery).response
+  def executeTagsQuery(tagsQuery: TagsQuery): Future[TagsResponse] = Results.TagsQueryResult(tagsQuery).response
+  def executeSectionsQuery(sectionsQuery: SectionsQuery): Future[SectionsResponse] = Results.SectionsQueryResult(sectionsQuery).response
+  def executeCollectionQuery(collectionQuery: CollectionQuery): Future[CollectionResponse] = Results.CollectionQueryResult(collectionQuery).response
 }
 
 class GuardianContentClient(val apiKey: String) extends ContentApiClientLogic

--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -77,7 +77,7 @@ trait ContentApiClientLogic {
   }
 
   def getResponse(itemQuery: ItemQuery): Future[ItemResponse] = {
-    val location = itemQuery.path.getOrElse(throw new Exception("No API URL provided to item query, ensure apiUrl/itemId is called"))
+    val location = itemQuery.id.getOrElse(throw new Exception("No API URL provided to item query, ensure apiUrl/itemId is called"))
     fetch(s"$targetUrl/$location", itemQuery.parameters) map JsonParser.parseItem
   }
   def getResponse(searchQuery: SearchQuery): Future[SearchResponse] =
@@ -87,7 +87,7 @@ trait ContentApiClientLogic {
   def getResponse(sectionsQuery: SectionsQuery): Future[SectionsResponse] =
     fetch(s"$targetUrl/sections", sectionsQuery.parameters) map JsonParser.parseSections
   def getResponse(collectionQuery: CollectionQuery): Future[CollectionResponse] = {
-    val location = collectionQuery.path.getOrElse(throw new Exception("No API URL provided to collection query, ensure apiUrl/collectionId is called"))
+    val location = collectionQuery.collectionId.getOrElse(throw new Exception("No API URL provided to collection query, ensure apiUrl/collectionId is called"))
     fetch(s"$targetUrl/collections/$location", collectionQuery.parameters) map JsonParser.parseCollection
   }
 

--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -60,8 +60,10 @@ trait ContentApiClientLogic {
     val headers = Map("User-Agent" -> "scala-client", "Accept" -> "application/json")
 
     for (response <- get(url(location, parameters), headers))
-    yield if (List(200, 302) contains response.statusCode) response.body
-    else throw new GuardianContentApiError(response.statusCode, response.statusMessage)
+    yield {
+      if (List(200, 302) contains response.statusCode) response.body
+      else throw new GuardianContentApiError(response.statusCode, response.statusMessage)
+    }
   }
 
   protected def get(url: String, headers: Map[String, String]): Future[HttpResponse] = {
@@ -78,51 +80,34 @@ trait ContentApiClientLogic {
    * Contains implicits to maintain `query.response` behaviour, along with
    * other methods that require a configured client
    */
-  object Results {
-    implicit class ItemQueryResult(itemQuery: ItemQuery) extends ItemQuery {
+  object implicits {
+    implicit class ItemQueryResult(itemQuery: ItemQuery) {
       def apiUrl(newContentPath: String): ItemQuery = {
-        require(newContentPath startsWith targetUrl, "apiUrl expects a full URL, use itemId if you only have an ID")
-        itemQuery.copy(path = Some(newContentPath))
+        require(newContentPath startsWith s"$targetUrl/", "apiUrl expects a full URL, use itemId if you only have an ID")
+        itemQuery.itemId(newContentPath.stripPrefix(s"$targetUrl/"))
       }
 
-      def itemId(contentId: String): ItemQuery = {
-        apiUrl(targetUrl + "/" + contentId)
-      }
-
-      lazy val response: Future[ItemResponse] = {
-        val location = itemQuery.path.getOrElse(throw new Exception("No API URL provided to item query, ensure withApiUrl is called"))
-        fetch(location, itemQuery.parameters) map JsonParser.parseItem
-      }
-
+      lazy val response: Future[ItemResponse] = getResponse(itemQuery)
       def asResponse = response
     }
 
 
     implicit class SearchQueryResult(searchQuery: SearchQuery) {
-      lazy val response: Future[SearchResponse] = {
-        fetch(targetUrl + "/search", searchQuery.parameters) map JsonParser.parseSearch
-      }
-
+      lazy val response: Future[SearchResponse] = getResponse(searchQuery)
       def asResponse = response
       def asContent = response.map(_.results)
     }
 
 
     implicit class TagsQueryResult(tagsQuery: TagsQuery) {
-      lazy val response: Future[TagsResponse] = {
-        fetch(targetUrl + "/tags", tagsQuery.parameters) map JsonParser.parseTags
-      }
-
+      lazy val response: Future[TagsResponse] = getResponse(tagsQuery)
       def asResponse = response
       def asTags = response.map(_.results)
     }
 
 
     implicit class SectionsQueryResult(sectionsQuery: SectionsQuery) {
-      lazy val response: Future[SectionsResponse] = {
-        fetch(targetUrl + "/sections", sectionsQuery.parameters) map JsonParser.parseSections
-      }
-
+      lazy val response: Future[SectionsResponse] = getResponse(sectionsQuery)
       def asResponse = response
       def asSections = response.map(_.results)
     }
@@ -130,29 +115,30 @@ trait ContentApiClientLogic {
 
     implicit class CollectionQueryResult(collectionQuery: CollectionQuery) {
       def apiUrl(newContentPath: String): CollectionQuery = {
-        require(newContentPath startsWith targetUrl, "apiUrl expects a full URI: use collectionId if you only have an ID")
-        collectionQuery.copy(path = Some(newContentPath))
+        require(newContentPath startsWith s"$targetUrl/collections/", "apiUrl expects a full URI: use collectionId if you only have an ID")
+        collectionQuery.collectionId(newContentPath.stripPrefix(s"$targetUrl/collections/"))
       }
 
-      def collectionId(collectionId: String): CollectionQuery = {
-        apiUrl(targetUrl + "/collections/" + collectionId)
-      }
-
-      lazy val response: Future[CollectionResponse] = {
-        val location = collectionQuery.path.getOrElse(throw new Exception("No API URL provided to collection query, ensure withApiUrl is called"))
-        fetch(location, collectionQuery.parameters) map JsonParser.parseCollection
-      }
-
+      lazy val response: Future[CollectionResponse] = getResponse(collectionQuery)
       def asResponse = response
       def asCollection = response.map(_.collection)
     }
   }
 
-  def executeItemQuery(itemQuery: ItemQuery): Future[ItemResponse] = Results.ItemQueryResult(itemQuery).response
-  def executeSearchQuery(searchQuery: SearchQuery): Future[SearchResponse] = Results.SearchQueryResult(searchQuery).response
-  def executeTagsQuery(tagsQuery: TagsQuery): Future[TagsResponse] = Results.TagsQueryResult(tagsQuery).response
-  def executeSectionsQuery(sectionsQuery: SectionsQuery): Future[SectionsResponse] = Results.SectionsQueryResult(sectionsQuery).response
-  def executeCollectionQuery(collectionQuery: CollectionQuery): Future[CollectionResponse] = Results.CollectionQueryResult(collectionQuery).response
+  def getResponse(itemQuery: ItemQuery): Future[ItemResponse] = {
+    val location = itemQuery.path.getOrElse(throw new Exception("No API URL provided to item query, ensure apiUrl/itemId is called"))
+    fetch(s"$targetUrl/$location", itemQuery.parameters) map JsonParser.parseItem
+  }
+  def getResponse(searchQuery: SearchQuery): Future[SearchResponse] =
+    fetch(s"$targetUrl/search", searchQuery.parameters) map JsonParser.parseSearch
+  def getResponse(tagsQuery: TagsQuery): Future[TagsResponse] =
+    fetch(s"$targetUrl/tags", tagsQuery.parameters) map JsonParser.parseTags
+  def getResponse(sectionsQuery: SectionsQuery): Future[SectionsResponse] =
+    fetch(s"$targetUrl/sections", sectionsQuery.parameters) map JsonParser.parseSections
+  def getResponse(collectionQuery: CollectionQuery): Future[CollectionResponse] = {
+    val location = collectionQuery.path.getOrElse(throw new Exception("No API URL provided to collection query, ensure apiUrl/collectionId is called"))
+    fetch(s"$targetUrl/collections/$location", collectionQuery.parameters) map JsonParser.parseCollection
+  }
 }
 
 class GuardianContentClient(val apiKey: String) extends ContentApiClientLogic

--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -90,51 +90,6 @@ trait ContentApiClientLogic {
     val location = collectionQuery.collectionId.getOrElse(throw new Exception("No API URL provided to collection query, ensure apiUrl/collectionId is called"))
     fetch(s"$targetUrl/collections/$location", collectionQuery.parameters) map JsonParser.parseCollection
   }
-
-  /**
-   * Contains implicits to maintain `query.response` behaviour, along with
-   * other methods that require a configured client
-   */
-  object implicits {
-    implicit class ItemQueryResult(itemQuery: ItemQuery) {
-      def apiUrl(newContentPath: String): ItemQuery = {
-        require(newContentPath startsWith s"$targetUrl/", "apiUrl expects a full URL, use itemId if you only have an ID")
-        itemQuery.itemId(newContentPath.stripPrefix(s"$targetUrl/"))
-      }
-
-      lazy val response: Future[ItemResponse] = getResponse(itemQuery)
-      def asResponse = response
-    }
-
-    implicit class SearchQueryResult(searchQuery: SearchQuery) {
-      lazy val response: Future[SearchResponse] = getResponse(searchQuery)
-      def asResponse = response
-      def asContent = response.map(_.results)
-    }
-
-    implicit class TagsQueryResult(tagsQuery: TagsQuery) {
-      lazy val response: Future[TagsResponse] = getResponse(tagsQuery)
-      def asResponse = response
-      def asTags = response.map(_.results)
-    }
-
-    implicit class SectionsQueryResult(sectionsQuery: SectionsQuery) {
-      lazy val response: Future[SectionsResponse] = getResponse(sectionsQuery)
-      def asResponse = response
-      def asSections = response.map(_.results)
-    }
-
-    implicit class CollectionQueryResult(collectionQuery: CollectionQuery) {
-      def apiUrl(newContentPath: String): CollectionQuery = {
-        require(newContentPath startsWith s"$targetUrl/collections/", "apiUrl expects a full URI: use collectionId if you only have an ID")
-        collectionQuery.collectionId(newContentPath.stripPrefix(s"$targetUrl/collections/"))
-      }
-
-      lazy val response: Future[CollectionResponse] = getResponse(collectionQuery)
-      def asResponse = response
-      def asCollection = response.map(_.collection)
-    }
-  }
 }
 
 class GuardianContentClient(val apiKey: String) extends ContentApiClientLogic

--- a/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -4,7 +4,7 @@ import com.gu.contentapi.client.{Parameter, Parameters}
 
 sealed trait ContentApiQuery
 
-case class ItemQuery(path: Option[String] = None, parameterHolder: Map[String, Parameter] = Map.empty)
+case class ItemQuery(id: Option[String] = None, parameterHolder: Map[String, Parameter] = Map.empty)
   extends ContentApiQuery
   with EditionParameters[ItemQuery]
   with ContentParameters[ItemQuery]
@@ -17,10 +17,10 @@ case class ItemQuery(path: Option[String] = None, parameterHolder: Map[String, P
   with FilterExtendedParameters[ItemQuery]
   with FilterSearchParameters[ItemQuery] {
 
-  def withParameters(parameterMap: Map[String, Parameter]) = copy(path, parameterMap)
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(id, parameterMap)
 
   def itemId(contentId: String): ItemQuery =
-    copy(path = Some(contentId))
+    copy(id = Some(contentId))
 }
 
 case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty)
@@ -54,17 +54,17 @@ case class SectionsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
   def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
 }
 
-case class CollectionQuery(path: Option[String] = None, parameterHolder: Map[String, Parameter] = Map.empty)
+case class CollectionQuery(collectionId: Option[String] = None, parameterHolder: Map[String, Parameter] = Map.empty)
   extends ContentApiQuery
   with ShowParameters[CollectionQuery]
   with ShowReferencesParameters[CollectionQuery]
   with FilterParameters[CollectionQuery]
   with FilterExtendedParameters[CollectionQuery] {
 
-  def withParameters(parameterMap: Map[String, Parameter]) = copy(path, parameterMap)
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(collectionId, parameterMap)
 
   def collectionId(collectionId: String): CollectionQuery =
-    copy(path = Some(collectionId))
+    copy(collectionId = Some(collectionId))
 }
 
 trait ContentParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>

--- a/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -1,0 +1,115 @@
+package com.gu.contentapi.client.model
+
+import com.gu.contentapi.client.{Parameter, Parameters}
+
+case class ItemQuery(path: Option[String] = None, parameterHolder: Map[String, Parameter] = Map.empty)
+  extends EditionParameters[ItemQuery]
+  with ContentParameters[ItemQuery]
+  with ShowParameters[ItemQuery]
+  with ShowReferencesParameters[ItemQuery]
+  with ShowExtendedParameters[ItemQuery]
+  with PaginationParameters[ItemQuery]
+  with OrderingParameters[ItemQuery]
+  with FilterParameters[ItemQuery]
+  with FilterExtendedParameters[ItemQuery]
+  with FilterSearchParameters[ItemQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(path, parameterMap)
+}
+
+case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ContentParameters[SearchQuery]
+  with ShowParameters[SearchQuery]
+  with ShowReferencesParameters[SearchQuery]
+  with OrderingParameters[SearchQuery]
+  with PaginationParameters[SearchQuery]
+  with FilterParameters[SearchQuery]
+  with FilterExtendedParameters[SearchQuery]
+  with FilterSearchParameters[SearchQuery] {
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+}
+
+case class TagsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ShowReferencesParameters[TagsQuery]
+  with PaginationParameters[TagsQuery]
+  with FilterParameters[TagsQuery]
+  with FilterTagParameters[TagsQuery]
+  with FilterSearchParameters[TagsQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+}
+
+case class SectionsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
+  extends FilterSearchParameters[SectionsQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+}
+
+case class CollectionQuery(path: Option[String] = None, parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ShowParameters[CollectionQuery]
+  with ShowReferencesParameters[CollectionQuery]
+  with FilterParameters[CollectionQuery]
+  with FilterExtendedParameters[CollectionQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(path, parameterMap)
+}
+
+trait ContentParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def contentSet = StringParameter("content-set")
+}
+
+trait EditionParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def edition = StringParameter("edition")
+}
+
+trait ShowParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def showFields = StringParameter("show-fields")
+  def showTags = StringParameter("show-tags")
+  def showElements = StringParameter("show-elements")
+  def showRights = StringParameter("show-rights")
+}
+
+trait ShowReferencesParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def showReferences = StringParameter("show-references")
+}
+
+trait ShowExtendedParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def showStoryPackage = BoolParameter("show-story-package")
+  def showRelated = BoolParameter("show-related")
+  def showMostViewed = BoolParameter("show-most-viewed")
+  def showEditorsPicks = BoolParameter("show-editors-picks")
+}
+
+trait PaginationParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def page = IntParameter("page")
+  def pageSize = IntParameter("page-size")
+}
+
+trait OrderingParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def orderBy = StringParameter("order-by")
+  def useDate = StringParameter("use-date")
+}
+
+trait FilterParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def section = StringParameter("section")
+  def reference = StringParameter("reference")
+  def referenceType = StringParameter("reference-type")
+  def productionOffice = StringParameter("production-office")
+}
+
+trait FilterExtendedParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def tag = StringParameter("tag")
+  def ids = StringParameter("ids")
+  def rights = StringParameter("rights")
+  def leadContent = StringParameter("lead-content")
+  def fromDate = DateParameter("from-date")
+  def toDate = DateParameter("to-date")
+}
+
+trait FilterTagParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def tagType = StringParameter("type")
+}
+
+trait FilterSearchParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def q = StringParameter("q")
+}

--- a/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -2,8 +2,11 @@ package com.gu.contentapi.client.model
 
 import com.gu.contentapi.client.{Parameter, Parameters}
 
+sealed trait ContentApiQuery
+
 case class ItemQuery(path: Option[String] = None, parameterHolder: Map[String, Parameter] = Map.empty)
-  extends EditionParameters[ItemQuery]
+  extends ContentApiQuery
+  with EditionParameters[ItemQuery]
   with ContentParameters[ItemQuery]
   with ShowParameters[ItemQuery]
   with ShowReferencesParameters[ItemQuery]
@@ -15,10 +18,14 @@ case class ItemQuery(path: Option[String] = None, parameterHolder: Map[String, P
   with FilterSearchParameters[ItemQuery] {
 
   def withParameters(parameterMap: Map[String, Parameter]) = copy(path, parameterMap)
+
+  def itemId(contentId: String): ItemQuery =
+    copy(path = Some(contentId))
 }
 
 case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-  extends ContentParameters[SearchQuery]
+  extends ContentApiQuery
+  with ContentParameters[SearchQuery]
   with ShowParameters[SearchQuery]
   with ShowReferencesParameters[SearchQuery]
   with OrderingParameters[SearchQuery]
@@ -30,7 +37,8 @@ case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty)
 }
 
 case class TagsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-  extends ShowReferencesParameters[TagsQuery]
+  extends ContentApiQuery
+  with ShowReferencesParameters[TagsQuery]
   with PaginationParameters[TagsQuery]
   with FilterParameters[TagsQuery]
   with FilterTagParameters[TagsQuery]
@@ -40,18 +48,23 @@ case class TagsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
 }
 
 case class SectionsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-  extends FilterSearchParameters[SectionsQuery] {
+  extends ContentApiQuery
+  with FilterSearchParameters[SectionsQuery] {
 
   def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
 }
 
 case class CollectionQuery(path: Option[String] = None, parameterHolder: Map[String, Parameter] = Map.empty)
-  extends ShowParameters[CollectionQuery]
+  extends ContentApiQuery
+  with ShowParameters[CollectionQuery]
   with ShowReferencesParameters[CollectionQuery]
   with FilterParameters[CollectionQuery]
   with FilterExtendedParameters[CollectionQuery] {
 
   def withParameters(parameterMap: Map[String, Parameter]) = copy(path, parameterMap)
+
+  def collectionId(collectionId: String): CollectionQuery =
+    copy(path = Some(collectionId))
 }
 
 trait ContentParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>

--- a/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -30,7 +30,7 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
   }
 
   it should "correctly add API key to request" in {
-    api.url("location", Map.empty) should include("api-key=test")
+    api.url("location", Map.empty) should include(s"api-key=${api.apiKey}")
   }
 
   it should "understand custom parameters" in {

--- a/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -56,7 +56,7 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
 
   it should "support itemQuery's apiUrl" in {
     val query = ItemQuery().apiUrl(s"${api.targetUrl}/commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
-    query.path.value should equal("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
+    query.id.value should equal("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
   }
 
   it should "perform a given collection query" in {
@@ -67,6 +67,6 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
 
   it should "support collectionQuery's apiUrl method" in {
     val query = CollectionQuery().apiUrl(s"${api.targetUrl}/collections/41cc-b696-db2e-0156")
-    query.path.value should equal("41cc-b696-db2e-0156")
+    query.collectionId.value should equal("41cc-b696-db2e-0156")
   }
 }

--- a/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -1,18 +1,18 @@
 package com.gu.contentapi.client
 
-import com.gu.contentapi.client.model.ItemQuery
+import com.gu.contentapi.client.model.{TagsQuery, CollectionQuery, ItemQuery}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span, Millis}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{OptionValues, FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext
 
-class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest with ScalaFutures {
+class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest with ScalaFutures with OptionValues {
 
   implicit def executionContext = ExecutionContext.global
   implicit override val patienceConfig = PatienceConfig(timeout = Span(2, Seconds))
-  import api.Results._
+  import api.implicits._
 
   "client interface" should "successfully call the Content API" in {
     val content = for {
@@ -48,11 +48,25 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
     params.get("aBoolParam") should be (Some("true"))
   }
 
-  it should "execute a given item query" in {
+  it should "perform a given item query" in {
     val query = ItemQuery().itemId("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
-    val content = for {
-      response <- api.executeItemQuery(query)
-    } yield response.content.get
+    val content = for (response <- api.getResponse(query)) yield response.content.get
     content.futureValue.id should be ("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
+  }
+
+  it should "support itemQuery's apiUrl" in {
+    val query = ItemQuery().apiUrl(s"${api.targetUrl}/commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
+    query.path.value should equal("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
+  }
+
+  it should "perform a given collection query" in {
+    val query = CollectionQuery().collectionId("uk-alpha/news/regular-stories")
+    val collection = for (response <- api.getResponse(query)) yield response.collection
+    collection.futureValue.id should equal("uk-alpha/news/regular-stories")
+  }
+
+  it should "support collectionQuery's apiUrl method" in {
+    val query = CollectionQuery().apiUrl(s"${api.targetUrl}/collections/41cc-b696-db2e-0156")
+    query.path.value should equal("41cc-b696-db2e-0156")
   }
 }

--- a/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -30,7 +30,7 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
   }
 
   it should "correctly add API key to request" in {
-    api.url("localtion", Map.empty) should include("api-key=test")
+    api.url("location", Map.empty) should include("api-key=test")
   }
 
   it should "understand custom parameters" in {

--- a/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -12,18 +12,18 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
 
   implicit def executionContext = ExecutionContext.global
   implicit override val patienceConfig = PatienceConfig(timeout = Span(2, Seconds))
-  import api.implicits._
 
   "client interface" should "successfully call the Content API" in {
+    val query = ItemQuery().itemId("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
     val content = for {
-      response <- api.item.itemId("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry").response
+      response <- api.getResponse(query)
     } yield response.content.get
     content.futureValue.id should be ("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
   }
 
   it should "return errors as a broken promise" in {
-    val errorResponse = api.item.itemId("something-that-does-not-exist").response
-    val errorTest = errorResponse recover { case error =>
+    val query = ItemQuery().itemId("something-that-does-not-exist")
+    val errorTest = api.getResponse(query) recover { case error =>
       error should be (GuardianContentApiError(404, "Not Found"))
     }
     errorTest.futureValue
@@ -54,19 +54,9 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
     content.futureValue.id should be ("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
   }
 
-  it should "support itemQuery's apiUrl" in {
-    val query = ItemQuery().apiUrl(s"${api.targetUrl}/commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
-    query.id.value should equal("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
-  }
-
   it should "perform a given collection query" in {
     val query = CollectionQuery().collectionId("uk-alpha/news/regular-stories")
     val collection = for (response <- api.getResponse(query)) yield response.collection
     collection.futureValue.id should equal("uk-alpha/news/regular-stories")
-  }
-
-  it should "support collectionQuery's apiUrl method" in {
-    val query = CollectionQuery().apiUrl(s"${api.targetUrl}/collections/41cc-b696-db2e-0156")
-    query.collectionId.value should equal("41cc-b696-db2e-0156")
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.8-SNAPSHOT"
+version in ThisBuild := "4.0-SNAPSHOT"


### PR DESCRIPTION
This allows users of the library to create CAPI queries without having access to a configured API client - it breaks the dependency between configuration, models and the execution of queries.

For example, someone building their own client library (for another team here, say) that needs to make CAPI calls as part of its working, we can now build instances of ItemQuery and and return them to the application for alteration (e.g. adding application-specific parameters) before executing the query. This was previously not possible because the ItemQuery type was accessable only from within a configured CAPI client. Beyond not being able to create instances of queries, this means it wasn't even possible to specify a function that uses those types e.g. `addAppParams(query: ItemQuery): ItemQuery`.

We move the query types out into the models package and remove their dependency on configuration properties like the api-key. In their place, we provide implicit conversions to restore this behaviour for existing clients along with providing new methods to execute these queries directly.

For existing clients using the `GuardianContentClient` class, compatibility is maintained by importing `<instance>.Results._`. For those using the trait they would import `Results._`. This backwards compatibility includes the `response` method as well as other helpers like `asResponse` and the `as<X>` methods.

@mchv has mentioned IRL that backwards compatibility may not be a priority for the team. If this is the case, these implicits can be removed in favour of directly executing the query from the new execute methods. I submit this PR with them because that represents that fundamental interface to the client at the moment and I'd like to prove that this doesn't undermine that.

Let's chat.

p.s. ~~git has made a an outrageous mess of this diff for `GuardianContentClient.scala`. It's much simpler than it looks~~ [edit, looks ok now]:

* remove the models
* replace them with the Results object
* add `url` method so we can still test the API key gets added
