### PR TITLE
Tell AsyncHttpClient not to re-use connections for more than 60s

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -20,6 +20,7 @@ trait ContentApiClientLogic {
     .setRequestTimeoutInMs(2000)
     .setCompressionEnabled(true)
     .setFollowRedirects(true)
+    .setMaxConnectionLifeTimeInMs(60000) // to respect DNS TTLs
   }
 
   val targetUrl = "http://content.guardianapis.com"


### PR DESCRIPTION
After another look through the AsyncHttpClient source code today, it turns out that it is possible to configure its connection pool to solve our DNS caching woes. I've checked with manual testing that this works as expected.

This is a better fix than #64 because it means we can keep Netty, so there are no performance worries.

By default AsyncHttpClient will keep a connection in the pool for ever:
https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.8.10/src/main/java/com/ning/http/client/AsyncHttpClientConfigDefaults.java#L56

The configured value is used here:
https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.8.10/src/main/java/com/ning/http/client/providers/netty/NettyConnectionsPool.java#L178

@mchv @LATaylor-guardian 