### PR TITLE
Support deserializing ISO dates (with optional millis) from JSON

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
+++ b/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
@@ -1,14 +1,15 @@
 package com.gu.contentapi.client.parser
 
-import org.json4s.DefaultFormats
-import org.json4s.JsonAST.{JField, JString, JBool}
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import org.json4s.{CustomSerializer, DefaultFormats}
+import org.json4s.JsonAST.{JNull, JField, JString, JBool}
 import org.json4s.native.JsonMethods
-import org.json4s.ext.DateTimeSerializer
 import com.gu.contentapi.client.model.{ItemResponse, SearchResponse, TagsResponse, SectionsResponse, CollectionResponse}
 
 object JsonParser {
 
-  implicit val formats = DefaultFormats + DateTimeSerializer
+  implicit val formats = DefaultFormats + BetterDateTimeSerializer
 
   def parseItem(json: String): ItemResponse = {
     (JsonMethods.parse(json) \ "response").transformField(fixFields).extract[ItemResponse]
@@ -36,3 +37,16 @@ object JsonParser {
   }
 
 }
+
+/** A Joda DateTime serializer that handles more flexible date formats, e.g. optional milliseconds */
+object BetterDateTimeSerializer extends CustomSerializer[DateTime](format => (
+  {
+    case JString(s) => ISODateTimeFormat.dateOptionalTimeParser().parseDateTime(s)
+    case JNull => null
+  },
+  {
+    // This is never used because we never generate JSON, only parse it
+    case d: DateTime => JString(format.dateFormat.format(d.toDate))
+  }
+))
+

--- a/src/test/resources/templates/item-content-with-blocks.json
+++ b/src/test/resources/templates/item-content-with-blocks.json
@@ -1,0 +1,89 @@
+{
+  "response": {
+    "status": "ok",
+    "userTier": "internal",
+    "total": 1,
+    "content": {
+      "id": "news/blog/live/2015/apr/09/example-liveblog",
+      "sectionId": "news",
+      "webTitle": "example-liveblog",
+      "blocks": {
+        "main": {
+          "bodyTextSummary": "",
+          "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"6cad8c36369fb82485257762dacc4ecf77e8ae55\"> <img src=\"http://media-origin.test.dev-guim.co.uk/6cad8c36369fb82485257762dacc4ecf77e8ae55/0_0_2464_1479/1000.jpg\" alt=\"Clive James\" width=\"1000\" height=\"600\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Mandatory Credit: Photo by REX (434909t) CLIVE JAMES - 21 OCT 2003 VARIOUS</span> <span class=\"element-image__credit\">Photograph: REX/REX</span> </figcaption> </figure>",
+          "attributes": {},
+          "id": "55267e40e4b06299e97da385",
+          "published": true,
+          "firstPublishedDate": "2015-04-09T14:27:28.486+01:00",
+          "publishedDate": "2015-04-09T14:27:35.492+01:00",
+          "contributors": []
+        },
+        "body": [{
+          "bodyTextSummary": "hi",
+          "bodyHtml": "<p>hi</p>",
+          "attributes": {},
+          "id": "5530debce4b078ada18a4602",
+          "published": true,
+          "firstPublishedDate": "2015-04-17T11:21:49.661+01:00",
+          "publishedDate": "2015-04-17T11:21:49.661+01:00",
+          "contributors": []
+        }, {
+          "bodyTextSummary": "more stuff",
+          "bodyHtml": "<p>more stuff</p>",
+          "attributes": {},
+          "id": "5530d2ede4b078ada18a45ff",
+          "published": true,
+          "firstPublishedDate": "2015-04-17T10:31:27.699+01:00",
+          "publishedDate": "2015-04-17T10:31:27.699+01:00",
+          "contributors": []
+        }, {
+          "bodyTextSummary": "",
+          "bodyHtml": "<figure class=\"element element-image\" data-media-id=\"251c09468a6373e52398964b2b3dd81ffedf1432\"> <img src=\"http://media-origin.test.dev-guim.co.uk/251c09468a6373e52398964b2b3dd81ffedf1432/0_0_2934_1759/1000.jpg\" alt=\"sdafasdf\" width=\"1000\" height=\"600\" class=\"gu-image\" /> <figcaption> <span class=\"element-image__caption\">Workers stand on scaffolding around the top of the Kremlin’s Spasskaya Tower to renovate it, in Moscow, Russia, Tuesday, April 7, 2015. The Spasskaya Tower has been hidden from view for repairs since December 2014. (AP Photo/Pavel Golovkin)</span> <span class=\"element-image__credit\">Photograph: Pavel Golovkin/AP</span> </figcaption> </figure>",
+          "attributes": {},
+          "id": "5527be22e4b0505fae058181",
+          "published": true,
+          "firstPublishedDate": "2015-04-10T13:12:22.026+01:00",
+          "publishedDate": "2015-04-10T13:12:22.026+01:00",
+          "contributors": []
+        }, {
+          "bodyTextSummary": "normal block here’s some stuff",
+          "bodyHtml": "<p>normal block</p> <p>here’s some stuff</p>",
+          "attributes": {},
+          "id": "55267d9de4b06299e97da384",
+          "published": true,
+          "firstPublishedDate": "2015-04-09T14:30:57.770+01:00",
+          "publishedDate": "2015-04-09T14:30:57.770+01:00",
+          "contributors": []
+        }, {
+          "bodyTextSummary": "key event text",
+          "bodyHtml": "<p>key event text</p>",
+          "attributes": {
+            "keyEvent": "true",
+            "title": "key event title"
+          },
+          "id": "55267da9e4b091b2a1c75fe0",
+          "published": true,
+          "firstPublishedDate": "2015-04-09T14:30:55.124+01:00",
+          "publishedDate": "2015-04-09T14:30:55.124+01:00",
+          "contributors": [],
+          "title": "key event title"
+        }, {
+          "bodyTextSummary": "summary text",
+          "bodyHtml": "<p>summary text</p>",
+          "attributes": {
+            "summary": "true"
+          },
+          "id": "55267dc0e4b091b2a1c75fe1",
+          "published": true,
+          "firstPublishedDate": "2015-04-09T14:30:51.832+01:00",
+          "publishedDate": "2015-04-09T14:30:51.832+01:00",
+          "contributors": []
+        }]
+      },
+      "webPublicationDate": "2015-04-17T10:21:49Z",
+      "webUrl": "http://www.theguardian.com/news/blog/live/2015/apr/09/example-liveblog",
+      "apiUrl": "http://content.guardianapis.com/news/blog/live/2015/apr/09/example-liveblog",
+      "sectionName": "News"
+    }
+  }
+}

--- a/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -7,6 +7,7 @@ import com.gu.contentapi.client.ClientTest
 class JsonParserItemTest extends FlatSpec with Matchers with ClientTest {
 
   val contentItemResponse = JsonParser.parseItem(loadJson("item-content.json"))
+  val contentItemWithBlocksResponse = JsonParser.parseItem(loadJson("item-content-with-blocks.json"))
   val tagItemResponse = JsonParser.parseItem(loadJson("item-tag.json"))
   val sectionItemResponse = JsonParser.parseItem(loadJson("item-section.json"))
 
@@ -193,6 +194,15 @@ class JsonParserItemTest extends FlatSpec with Matchers with ClientTest {
     sectionItemResponse.edition.get.code should be ("default")
     sectionItemResponse.edition.get.webUrl should be ("http://www.theguardian.com/commentisfree")
     sectionItemResponse.edition.get.apiUrl should be ("http://content.guardianapis.com/commentisfree")
+  }
+
+
+  it should "parse the publication date of content" in {
+    contentItemWithBlocksResponse.content.get.webPublicationDateOption should be(Some(new DateTime("2015-04-17T10:21:49Z")))
+  }
+
+  it should "parse the publication dates of blocks" in {
+    contentItemWithBlocksResponse.content.get.blocks.get.main.get.firstPublishedDate should be(Some(new DateTime("2015-04-09T14:27:28.486+01:00")))
   }
 
 }


### PR DESCRIPTION
This fixes a bug where the publishedDate and firstPublishedDate were not being deserialized