### PR TITLE
Update to dispatch v0.11.3, to avoid clashes when using Play v2.4.0

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -34,7 +34,7 @@ object ContentApiClientBuild extends Build {
       "joda-time" % "joda-time" % "2.3",
       "org.json4s" %% "json4s-native" % "3.2.11",
       "org.json4s" %% "json4s-ext" % "3.2.11",
-      "net.databinder.dispatch" %% "dispatch-core" % "0.11.2",
+      "net.databinder.dispatch" %% "dispatch-core" % "0.11.3",
       "org.scalatest" %% "scalatest" % "2.2.1" % "test"
     ),
     pomExtra := (

--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -13,14 +13,14 @@ trait ContentApiClientLogic {
   val apiKey: String
 
   protected val http = Http configure { _
-    .setAllowPoolingConnection(true)
-    .setMaximumConnectionsPerHost(10)
-    .setMaximumConnectionsTotal(10)
-    .setConnectionTimeoutInMs(1000)
-    .setRequestTimeoutInMs(2000)
-    .setCompressionEnabled(true)
-    .setFollowRedirects(true)
-    .setMaxConnectionLifeTimeInMs(60000) // to respect DNS TTLs
+    .setAllowPoolingConnections(true)
+    .setMaxConnectionsPerHost(10)
+    .setMaxConnections(10)
+    .setConnectTimeout(1000)
+    .setRequestTimeout(2000)
+    .setCompressionEnforced(true)
+    .setFollowRedirect(true)
+    .setConnectionTTL(60000) // to respect DNS TTLs
   }
 
   val targetUrl = "http://content.guardianapis.com"


### PR DESCRIPTION
Play v2.4.0 uses an updated version of `async-http-client`, which clashes with the version used in dispatch v0.11.2. They can't co-exist happily, so to use Play v2.4.0, we need to update dispatch (and thus async-http-client)

* dispatch v0.11.2	uses	async-http-client v1.8.10
* dispatch v0.11.3	uses	async-http-client v1.9.11

`async-http-client` went through a couple of config-parameter renames in this time:

* https://github.com/AsyncHttpClient/async-http-client/commit/c90cf8628bdcf1bfca6cb512c08ead143914b82f
* https://github.com/AsyncHttpClient/async-http-client/commit/b06e0868826df349b8796800c453ec2d44259dd3