### PR TITLE
Add isMaster to imageTypeData

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/model/Model.scala
+++ b/src/main/scala/com.gu.contentapi.client/model/Model.scala
@@ -454,7 +454,8 @@ case class ImageTypeData(
   mediaApiUri: Option[String],
   picdarUrn: Option[String],
   suppliersReference: Option[String],
-  imageType: Option[String]
+  imageType: Option[String],
+  isMaster: Option[Boolean]
 )
 
 case class AssetTypeData(

--- a/src/test/resources/templates/item-content-with-blocks.json
+++ b/src/test/resources/templates/item-content-with-blocks.json
@@ -110,7 +110,8 @@
                   "mediaApiUri":"https://api.media.test.dev-gutools.co.uk/images/e38889cd5697318e26258f29e0036cd9633f2dbf",
                   "picdarUrn":"GD*52757191",
                   "suppliersReference":"Nic6447359",
-                  "imageType":"Photograph"
+                  "imageType":"Photograph",
+                  "isMaster": true
                 },
                 "type": "image"
               }

--- a/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -315,6 +315,7 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
     imageTypeData.picdarUrn.get should be ("GD*52757191")
     imageTypeData.suppliersReference.get should be ("Nic6447359")
     imageTypeData.imageType.get should be ("Photograph")
+    imageTypeData.isMaster.get should be (true)
   }
 
   it should "have the correct typeData for a audio element for a block" in {


### PR DESCRIPTION
In order to allow consumers to distinguish master assets.