### PR TITLE
Decouple http client

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -42,7 +42,6 @@ object ContentApiClientBuild extends Build {
       "joda-time" % "joda-time" % "2.3",
       "org.json4s" %% "json4s-native" % "3.2.11",
       "org.json4s" %% "json4s-ext" % "3.2.11",
-      "net.databinder.dispatch" %% "dispatch-core" % "0.11.3",
       "org.scalatest" %% "scalatest" % "2.2.1" % "test"
     ),
     pomExtra := (

--- a/src/test/scala/com.gu.contentapi.client/ClientTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/ClientTest.scala
@@ -1,10 +1,14 @@
 package com.gu.contentapi.client
 
+import scala.concurrent.{Future, ExecutionContext}
 import scala.io.Source
 
 trait ClientTest {
 
-  val api = new GuardianContentClient("test")
+  val api = new GuardianContentClient(
+    apiKey = "test",
+    httpClient = new FakeHttpClient(ExampleResponses.responses, ExampleResponses.notFoundResponse)
+  )
 
   def loadJson(filename: String): String = {
     Source.fromFile("src/test/resources/templates/" + filename).mkString

--- a/src/test/scala/com.gu.contentapi.client/ExampleResponses.scala
+++ b/src/test/scala/com.gu.contentapi.client/ExampleResponses.scala
@@ -1,0 +1,62 @@
+package com.gu.contentapi.client
+
+object ExampleResponses {
+
+  val notFoundJson =
+    """{
+      |  "response": {
+      |    "status": "error",
+      |    "message": "The requested resource could not be found."
+      |  }
+      |}""".stripMargin
+
+  val notFoundResponse = HttpResponse(body = notFoundJson, statusCode = 404, statusMessage = "Not Found")
+
+  val cyclistsJson =
+    """{
+      |  "response": {
+      |    "status": "ok",
+      |    "userTier": "developer",
+      |    "total": 1,
+      |    "content": {
+      |      "type": "article",
+      |      "sectionId": "commentisfree",
+      |      "webTitle": "Just like cyclists, pedestrians must find a sense of self-righteousness | Zoe Williams",
+      |      "webPublicationDate": "2012-08-01T20:15:00Z",
+      |      "id": "commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry",
+      |      "webUrl": "http://www.theguardian.com/commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry",
+      |      "apiUrl": "http://content.guardianapis.com/commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry",
+      |      "sectionName": "Comment is free"
+      |    }
+      |  }
+      |}""".stripMargin
+
+  val cyclistsResponse = HttpResponse(body = cyclistsJson, statusCode = 200, statusMessage = "OK")
+
+  val removedJson =
+    """{
+      |  "response": {
+      |    "status": "ok",
+      |    "userTier": "developer",
+      |    "total": 3,
+      |    "startIndex": 1,
+      |    "pageSize": 10,
+      |    "currentPage": 1,
+      |    "pages": 1,
+      |    "orderBy": "newest",
+      |    "results": [
+      |      "some/removed/content/0",
+      |      "some/removed/content/1",
+      |      "some/removed/content/2"
+      |    ]
+      |  }
+      |}
+    """.stripMargin
+
+  val removedResponse = HttpResponse(body = removedJson, statusCode = 200, statusMessage = "OK")
+
+  val responses = Map(
+    "http://content.guardianapis.com/commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry?api-key=test" -> cyclistsResponse,
+    "http://content.guardianapis.com/content/removed?reason=expired&api-key=test" -> removedResponse
+  )
+}

--- a/src/test/scala/com.gu.contentapi.client/FakeHttpClient.scala
+++ b/src/test/scala/com.gu.contentapi.client/FakeHttpClient.scala
@@ -1,0 +1,9 @@
+package com.gu.contentapi.client
+
+import scala.concurrent.{Future, ExecutionContext}
+
+class FakeHttpClient(responses: Map[String, HttpResponse], default: HttpResponse) extends HttpClient {
+
+  override def get(url: String, headers: Map[String, String])(implicit context: ExecutionContext) =
+    Future.successful(responses.getOrElse(url, default))
+}

--- a/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -56,6 +56,6 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
     val query = api.removedContent.reason("expired")
     val results = for (response <- api.getResponse(query)) yield response.results
     val fResults = results.futureValue
-    fResults.size should be (10)
+    fResults.size should be (3)
   }
 }


### PR DESCRIPTION
Removes dependency on dispatch which stops the content-api-client being
tightly coupled to a specific Play version.  Has the added bonus of allowing tests to run without an internet connection.

Mobile-apps cannot currently upgrade to the most recent version of this client because we are still on Play 2.3.8.