### PR TITLE
Simplify injecting alternative http client

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -15,7 +15,7 @@ trait ContentApiClientLogic {
 
   private val userAgent = "content-api-scala-client/"+BuildInfo.version
 
-  protected val http = Http configure { _
+  protected lazy val http = Http configure { _
     .setAllowPoolingConnections(true)
     .setMaxConnectionsPerHost(10)
     .setMaxConnections(10)


### PR DESCRIPTION
This small change enables library users to exclude com.ning.async-http-client and extend GuardianContentClient to inject an alternative client