### PR TITLE
Parse CAPI json response on error

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -8,7 +8,7 @@ import com.gu.contentapi.buildinfo.BuildInfo
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class GuardianContentApiError(httpStatus: Int, httpMessage: String) extends Exception(httpMessage)
+case class GuardianContentApiError(httpStatus: Int, httpMessage: String, errorResponse: Option[ErrorResponse] = None) extends Exception(httpMessage)
 
 trait ContentApiClientLogic {
   val apiKey: String
@@ -48,7 +48,7 @@ trait ContentApiClientLogic {
 
     for (response <- get(url, headers)) yield {
       if (List(200, 302) contains response.statusCode) response.body
-      else throw new GuardianContentApiError(response.statusCode, response.statusMessage)
+      else throw new GuardianContentApiError(response.statusCode, response.statusMessage, JsonParser.parseError(response.body))
     }
   }
 

--- a/src/main/scala/com.gu.contentapi.client/model/Responses.scala
+++ b/src/main/scala/com.gu.contentapi.client/model/Responses.scala
@@ -63,3 +63,5 @@ case class ItemResponse(
     mostViewed: List[Content],
     storyPackage: List[Content],
     leadContent: List[Content])
+
+case class ErrorResponse(status: String, message: String)

--- a/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
+++ b/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
@@ -35,6 +35,12 @@ object JsonParser {
     (JsonMethods.parse(json) \ "response").extract[EditionsResponse]
   }
 
+  def parseError(json: String): Option[ErrorResponse] = for {
+    parsedJson <- JsonMethods.parseOpt(json)
+    response = parsedJson \ "response"
+    errorResponse <- response.extractOpt[ErrorResponse]
+  } yield errorResponse
+
   private def fixFields: PartialFunction[JField, JField] = {
     case JField("isExpired", JString(s)) => JField("isExpired", JBool(s.toBoolean))
     case JField("webPublicationDate", JString(s)) => JField("webPublicationDateOption", JString(s))

--- a/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -1,6 +1,6 @@
 package com.gu.contentapi.client
 
-import com.gu.contentapi.client.model.ItemQuery
+import com.gu.contentapi.client.model.{ErrorResponse, ItemQuery}
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
@@ -22,7 +22,7 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
   it should "return errors as a broken promise" in {
     val query = ItemQuery("something-that-does-not-exist")
     val errorTest = api.getResponse(query) recover { case error =>
-      error should be (GuardianContentApiError(404, "Not Found"))
+      error should be (GuardianContentApiError(404, "Not Found", Some(ErrorResponse("error", "The requested resource could not be found."))))
     }
     errorTest.futureValue
   }


### PR DESCRIPTION
Allow users of the client to identify the reason why content is gone.