### PR TITLE
Add thrift declaration for content to built jar file.

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -30,6 +30,7 @@ object ContentApiClientBuild extends Build {
   .settings(sonatypeSettings: _*)
   .settings(
     ScroogeSBT.scroogeThriftOutputFolder in Compile := sourceManaged.value / "thrift",
+    unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" },
     scalaVersion := "2.11.7",
     crossScalaVersions := Seq("2.11.7", "2.10.5"),
     organization := "com.gu",


### PR DESCRIPTION
- This allows the thrift declaration to be included and used by other services using the content-api-scala-client. For example for inclusion in notifications by crier.