### PR TITLE
Make userAgent protected

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -15,7 +15,7 @@ case class GuardianContentApiError(httpStatus: Int, httpMessage: String, errorRe
 trait ContentApiClientLogic {
   val apiKey: String
 
-  private val userAgent = "content-api-scala-client/"+CapiBuildInfo.version
+  protected val userAgent = "content-api-scala-client/"+CapiBuildInfo.version
 
   protected lazy val http = {
     /*


### PR DESCRIPTION
If overriding `http` in a consuming class access to `userAgent` is required.