### PR TITLE
Add additional fields to thrift model.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 7.2
+* Additional fields added to block elements.
+* 'durationMinutes' and 'durationSeconds' fields added to AssetFields.
+* 'legallySensitive' field added to ContentFields.
+* Travis file added.
+* Remove incorrectly added isMaster field.
+
+## 7.1
+* Add thrift definition to built jar file.
+
+## 7.0
+* Define and generate the Content API data model via Scrooge using Thrift. 
+
 ## 6.10
 * Provide proper parsing of error responses.
 * Add support for the `type` field on `Content`, including a filter to search by content type.

--- a/src/main/thrift/content/v1.thrift
+++ b/src/main/thrift/content/v1.thrift
@@ -204,6 +204,10 @@ struct AssetFields {
   14: optional bool isMaster
 
   15: optional i64 sizeInBytes
+
+  16: optional i32 durationMinutes
+
+  17: optional i32 durationSeconds
 }
 
 struct Asset {
@@ -711,6 +715,8 @@ struct ContentFields {
     33: optional bool showInRelatedContent
 
     34: optional string thumbnail
+
+    35: optional bool legallySensitive
 }
 
 struct Reference {

--- a/src/test/resources/templates/item-content.json
+++ b/src/test/resources/templates/item-content.json
@@ -48,7 +48,8 @@
                 "internalComposerCode": "55e953ebe4b019bd8fe33524",
                 "contributorBio": "EMEA marketing director at xAd",
                 "starRating": "4",
-                "newspaperPageNumber": "3"
+                "newspaperPageNumber": "3",
+                "legallySensitive": false
             },
             "tags": [
                 {

--- a/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -104,6 +104,7 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
     contentFields.byline should be (Some("Joanna Blythman"))
     contentFields.productionOffice should be (Some(Office.Uk))
     contentFields.liveBloggingNow should be (Some(false))
+    contentFields.legallySensitive should be (Some(false))
 
     val expectedCommentCloseDate = CapiDateTime(new DateTime("2013-01-19T10:14:00Z").getMillis)
     contentFields.commentCloseDate should be (Some(expectedCommentCloseDate))


### PR DESCRIPTION
- Add 'durationMinutes' and 'durationSeconds' field to AssetFields.
- Add 'legallySensitive' field to ContentFields.