### PR TITLE
Add MaxSearchQueryIdSize to Limits

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/Limits.scala
+++ b/src/main/scala/com.gu.contentapi.client/Limits.scala
@@ -9,4 +9,5 @@ object Limits {
   private val SafetyBufferSize = 100
 
   val UrlSize = AcceptedUrlSize - (MaxEc2HostNameSize + MaximumTierParameterSize + SafetyBufferSize)
+  val MaxSearchQueryIdSize = 50
 }


### PR DESCRIPTION
There is a limit of 50 on the maximum number of `ids` a search query can accept.

@LATaylor-guardian 