### PR TITLE
Add the podcast.metadata.image field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.6
+* Added the image field to Podcast metadata
+
 ## 7.5
 * Added thumbnailUrl, role, mediaId, iframeUrl, scriptName, scriptUrl, blockAds to AssetFields.
 * Added allowUgc to ContentFields.

--- a/project/build.scala
+++ b/project/build.scala
@@ -44,6 +44,7 @@ object ContentApiClientBuild extends Build {
     maxErrors := 20,
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
     scalacOptions ++= Seq("-deprecation", "-unchecked"),
+
     libraryDependencies ++= Seq(
       "org.json4s" %% "json4s-native" % "3.3.0.RC4",
       "org.json4s" %% "json4s-ext" % "3.3.0.RC4",

--- a/src/main/thrift/content/v1.thrift
+++ b/src/main/thrift/content/v1.thrift
@@ -756,6 +756,8 @@ struct Podcast {
     4: optional string subscriptionUrl
 
     5: required bool explicit
+
+    6: optional string image
 }
 
 struct Tag {

--- a/src/test/resources/templates/item-tag.json
+++ b/src/test/resources/templates/item-tag.json
@@ -18,7 +18,9 @@
                 "linkUrl": "http://www.theguardian.com/",
                 "author": "theguardian.com",
                 "copyright": "theguardian.com © 2014",
-                "explicit": true
+                "explicit": true,
+                "image": "http://www.theguardian.com/images/lol.jpg",
+                "subscriptionUrl": "http://phobos.apple.com/WebObjects/MZStore.woa/wa/viewPodcast?id=188674007"
             },
             "webUrl": "http://www.theguardian.com/world/france",
             "apiUrl": "http://content.guardianapis.com/world/france"

--- a/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -210,6 +210,8 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
     tag.podcast.get.author should be ("theguardian.com")
     tag.podcast.get.copyright should be ("theguardian.com © 2014")
     tag.podcast.get.explicit should be (true)
+    tag.podcast.get.image.value should be ("http://www.theguardian.com/images/lol.jpg")
+    tag.podcast.get.subscriptionUrl.value should be ("http://phobos.apple.com/WebObjects/MZStore.woa/wa/viewPodcast?id=188674007")
     tag.webUrl should be ("http://www.theguardian.com/world/france")
     tag.apiUrl should be ("http://content.guardianapis.com/world/france")
   }


### PR DESCRIPTION
Also, whoever added the `podcast.metadata.subscriptionUrl` field forgot to write a test for it, I squeezed it into this PR.