### PR TITLE
Add explicit field & audio type tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.8
+* Add explicit field to AssetFields
+* Add tests for audio elements
+
 ## 7.7
 * Added the `embedType` and `html` fields to asset fields
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 7.8
 * Add explicit field to AssetFields
 * Add tests for audio elements
+* Add durationMinutes, durationSeconds and clean field to AudioElementField
 
 ## 7.7
 * Added the `embedType` and `html` fields to asset fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 7.8
 * Add explicit field to AssetFields
 * Add tests for audio elements
-* Add durationMinutes, durationSeconds and clean field to AudioElementField
+* Add durationMinutes, durationSeconds, explicit and clean field to AudioElementField
 
 ## 7.7
 * Added the `embedType` and `html` fields to asset fields

--- a/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
+++ b/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
@@ -75,6 +75,7 @@ object JsonParser {
     case JField("displayCredit", JString(s)) => JField("displayCredit", JBool(s.toBoolean))
     case JField("legallySensitive", JString(s)) => JField("legallySensitive", JBool(s.toBoolean))
     case JField("sensitive", JString(s)) => JField("sensitive", JBool(s.toBoolean))
+    case JField("explicit", JString(s)) => JField("explicit", JBool(s.toBoolean))
   }
 
   def generateJson[A <: ThriftEnum]: PartialFunction[Any, JString] = {

--- a/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
+++ b/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
@@ -76,6 +76,7 @@ object JsonParser {
     case JField("legallySensitive", JString(s)) => JField("legallySensitive", JBool(s.toBoolean))
     case JField("sensitive", JString(s)) => JField("sensitive", JBool(s.toBoolean))
     case JField("explicit", JString(s)) => JField("explicit", JBool(s.toBoolean))
+    case JField("clean", JString(s)) => JField("clean", JBool(s.toBoolean))
   }
 
   def generateJson[A <: ThriftEnum]: PartialFunction[Any, JString] = {

--- a/src/main/thrift/content/v1.thrift
+++ b/src/main/thrift/content/v1.thrift
@@ -291,6 +291,8 @@ struct AudioElementFields {
     8: optional i32 durationSeconds
 
     9: optional bool clean
+
+    10: optional bool explicit
 }
 
 struct VideoElementFields {

--- a/src/main/thrift/content/v1.thrift
+++ b/src/main/thrift/content/v1.thrift
@@ -230,6 +230,8 @@ struct AssetFields {
 
   27: optional string embedType
 
+  28: optional bool explicit
+
 }
 
 struct Asset {

--- a/src/main/thrift/content/v1.thrift
+++ b/src/main/thrift/content/v1.thrift
@@ -285,6 +285,12 @@ struct AudioElementFields {
     5: optional string credit
 
     6: optional string caption
+
+    7: optional i32 durationMinutes
+
+    8: optional i32 durationSeconds
+
+    9: optional bool clean
 }
 
 struct VideoElementFields {

--- a/src/test/resources/templates/item-content-with-blocks.json
+++ b/src/test/resources/templates/item-content-with-blocks.json
@@ -82,7 +82,10 @@
                   "description": "Listen to user48736353001 | Explore the largest community of artists, bands, podcasters and creators of music & audio.",
                   "title":"user48736353001",
                   "credit":"Audio credit",
-                  "caption":"Audio caption"
+                  "caption":"Audio caption",
+                  "durationMinutes":9,
+                  "durationSeconds":41,
+                  "clean":true
                 },
                 "type": "audio"
               },

--- a/src/test/resources/templates/item-content-with-blocks.json
+++ b/src/test/resources/templates/item-content-with-blocks.json
@@ -85,7 +85,8 @@
                   "caption":"Audio caption",
                   "durationMinutes":9,
                   "durationSeconds":41,
-                  "clean":true
+                  "clean":true,
+                  "explicit":false
                 },
                 "type": "audio"
               },

--- a/src/test/resources/templates/item-content.json
+++ b/src/test/resources/templates/item-content.json
@@ -422,6 +422,24 @@
                             }
                         }
                     ]
+                },
+                {
+                    "id": "gu-audio-458408910",
+                    "relation": "main",
+                    "type": "audio",
+                    "assets": [
+                        {
+                            "type": "audio",
+                            "mimeType": "audio/mpeg",
+                            "file": "http://static.guim.co.uk/audio/kip/football/series/footballweekly/1447937149295/5649/FW-nov19-2015.mp3",
+                            "typeData": {
+                                "explicit": false,
+                                "source": "guardian.co.uk",
+                                "durationMinutes": "60",
+                                "durationSeconds": "17"
+                            }
+                        }
+                    ]
                 }
             ],
             "references": [],

--- a/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -414,6 +414,7 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
     audioElementFields.durationMinutes.get should be (9)
     audioElementFields.durationSeconds.get should be (41)
     audioElementFields.clean.get should be (true)
+    audioElementFields.explicit.get should be (false)
   }
 
   it should "have the correct typeData for a pull quote element for a block" in {

--- a/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -137,7 +137,7 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
   }
 
   it should "parse content elements" in {
-    contentItemResponse.content.get.elements.get.size should be (2)
+    contentItemResponse.content.get.elements.get.size should be (3)
 
     val element = contentItemResponse.content.get.elements.get.head
     element.id should be ("gu-image-402807041")
@@ -168,6 +168,18 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
     elementAssetFields.html should be (Some("html"))
     elementAssetFields.embedType should be (Some("embedType"))
     elementAssetFields.blockAds should be (Some(false))
+
+    // check audio elements too
+    val audioElement = contentItemResponse.content.get.elements.get.apply(2).assets.head
+    audioElement.`type` should be (AssetType.Audio)
+    audioElement.mimeType should be (Some("audio/mpeg"))
+    audioElement.file should be (Some("http://static.guim.co.uk/audio/kip/football/series/footballweekly/1447937149295/5649/FW-nov19-2015.mp3"))
+
+    val audioElementAssetFields = audioElement.typeData.get
+    audioElementAssetFields.explicit should be (Some(false))
+    audioElementAssetFields.source should be (Some("guardian.co.uk"))
+    audioElementAssetFields.durationMinutes should be (Some(60))
+    audioElementAssetFields.durationSeconds should be (Some(17))
   }
 
   it should "parse content references" in {

--- a/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -411,6 +411,9 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
     audioElementFields.credit.get should be ("Audio credit")
     audioElementFields.source.get should be ("Soundcloud")
     audioElementFields.title.get should be ("user48736353001")
+    audioElementFields.durationMinutes.get should be (9)
+    audioElementFields.durationSeconds.get should be (41)
+    audioElementFields.clean.get should be (true)
   }
 
   it should "have the correct typeData for a pull quote element for a block" in {


### PR DESCRIPTION
The name of the branch/PR doesn't make too much sense anymore but we decided to squeeze a few more related fields in a single release.

* Add explicit field to AssetFields
* Add tests for assets audio elements
* Add durationMinutes, durationSeconds and clean field to AudioElementField