### PR TITLE
Add clean field to AssetFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.9
+* Add `clean` field to AssetFields
+
 ## 7.8
 * Add explicit field to AssetFields
 * Add tests for audio elements

--- a/src/main/thrift/content/v1.thrift
+++ b/src/main/thrift/content/v1.thrift
@@ -232,6 +232,7 @@ struct AssetFields {
 
   28: optional bool explicit
 
+  29: optional bool clean
 }
 
 struct Asset {

--- a/src/test/resources/templates/item-content.json
+++ b/src/test/resources/templates/item-content.json
@@ -434,6 +434,7 @@
                             "file": "http://static.guim.co.uk/audio/kip/football/series/footballweekly/1447937149295/5649/FW-nov19-2015.mp3",
                             "typeData": {
                                 "explicit": false,
+                                "clean": true,
                                 "source": "guardian.co.uk",
                                 "durationMinutes": "60",
                                 "durationSeconds": "17"

--- a/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -177,6 +177,7 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
 
     val audioElementAssetFields = audioElement.typeData.get
     audioElementAssetFields.explicit should be (Some(false))
+    audioElementAssetFields.clean should be (Some(true))
     audioElementAssetFields.source should be (Some("guardian.co.uk"))
     audioElementAssetFields.durationMinutes should be (Some(60))
     audioElementAssetFields.durationSeconds should be (Some(17))


### PR DESCRIPTION
Sorry for rolling out a new version for one field only - I could have done this in my previous PR... had I known the editor wanted the extra field :)

(I need to roll out a new version of the client cause I'm using it for the iTunes RSS feed)