### PR TITLE
Parse "keyEvent" and "summary" boolean properties in block attributes

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
+++ b/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
@@ -46,6 +46,8 @@ object JsonParser {
   } yield errorResponse
 
   private def fixFields: PartialFunction[JField, JField] = {
+    case JField("summary", JString(s)) => JField("summary", JBool(s.toBoolean))
+    case JField("keyEvent", JString(s)) => JField("keyEvent", JBool(s.toBoolean))
     case JField("showInRelatedContent", JString(s)) => JField("showInRelatedContent", JBool(s.toBoolean))
     case JField("shouldHideAdverts", JString(s)) => JField("shouldHideAdverts", JBool(s.toBoolean))
     case JField("hasStoryPackage", JString(s)) => JField("hasStoryPackage", JBool(s.toBoolean))

--- a/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -337,6 +337,24 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
     blockElements.size should be (6)
   }
 
+  it should "parse keyEvent attribute " in {
+    val bodyBlocks = contentItemWithBlocksResponse.content.get.blocks.get.body.get
+    val keyEvent = bodyBlocks.filter(_.id == "55267da9e4b091b2a1c75fe0").head
+    val nonKeyEvent = bodyBlocks.filter(_.id == "55267dc0e4b091b2a1c75fe1").head
+
+    keyEvent.attributes.keyEvent shouldBe Some(true)
+    nonKeyEvent.attributes.keyEvent shouldBe None
+  }
+
+  it should "parse summary attribute " in {
+    val bodyBlocks = contentItemWithBlocksResponse.content.get.blocks.get.body.get
+    val noSummary = bodyBlocks.filter(_.id == "55267da9e4b091b2a1c75fe0").head
+    val summary = bodyBlocks.filter(_.id == "55267dc0e4b091b2a1c75fe1").head
+
+    summary.attributes.summary shouldBe Some(true)
+    noSummary.attributes.summary shouldBe None
+  }
+
   it should "parse a text element for a block" in {
     val textElement = getBlockElementsOfType(contentItemWithBlocksResponse, `type` = ElementType.Text)
 


### PR DESCRIPTION
While debugging an issue in MAPI I realized the blocks I was getting from the content api client always had KeyEvent and summary set to None.