### PR TITLE
Add crossword to the thrift model

### DIFF
--- a/src/main/thrift/content/v1.thrift
+++ b/src/main/thrift/content/v1.thrift
@@ -14,7 +14,8 @@ enum ContentType {
     GALLERY = 2,
     INTERACTIVE = 3,
     PICTURE = 4,
-    VIDEO = 5
+    VIDEO = 5,
+    CROSSWORD = 6
 }
 
 /*


### PR DESCRIPTION
We already have content with `crossword` type, so we should add it and release a new version of the scala client,  