### PR TITLE
Fix deserialisation of crossword separatorLocations field

### DIFF
--- a/src/main/thrift/content/v1.thrift
+++ b/src/main/thrift/content/v1.thrift
@@ -606,13 +606,6 @@ struct CrosswordCreator {
     2: required string webUrl
 }
 
-struct SeparatorLocation {
-
-    1: optional string separator
-
-    2: optional list<i32> locations
-}
-
 struct CrosswordEntry {
 
     1: required string id
@@ -625,7 +618,7 @@ struct CrosswordEntry {
 
     5: optional CrosswordPosition position
 
-    6: optional list<SeparatorLocation> separatorLocations
+    6: optional map<string, list<i32>> separatorLocations
 
     7: optional i32 length
 

--- a/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -491,6 +491,7 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
      crossword.number should be(24623)
      crossword.dimensions.cols should be(15)
      crossword.entries.head.id should be("8-across")
+     crossword.entries.head.separatorLocations should be(Some(Map("," -> Seq(4))))
    }
 
   private def getBlockElementsOfType(response: ItemResponse, `type`: ElementType): Seq[BlockElement] = {


### PR DESCRIPTION
Fixed by simplifying the Thrift model. We were using a custom type for separator locations, but we hadn't implemented the required custom deserializer for it. It turned out to be quite fiddly to do so, and the type wasn't really necessary, so I just deleted it.

/cc @rich-nguyen