### PR TITLE
Add embed asset type

### DIFF
--- a/src/main/thrift/content/v1.thrift
+++ b/src/main/thrift/content/v1.thrift
@@ -158,7 +158,8 @@ enum Office {
 enum AssetType {
     IMAGE = 0,
     VIDEO = 1,
-    AUDIO = 2
+    AUDIO = 2,
+    EMBED = 3
 }
 
 enum MembershipTier {


### PR DESCRIPTION
[Example existing article with this kind of asset](http://content.guardianapis.com/us-news/2015/oct/20/planned-parenthood-defund-texas?show-elements=embed&api-key=internal tier key)

@rich-nguyen 