### PR TITLE
add the content atoms model to the response

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -99,6 +99,7 @@ trait ShowParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { thi
   def showElements = StringParameter("show-elements")
   def showRights = StringParameter("show-rights")
   def showBlocks = StringParameter("show-blocks")
+  def showAtoms  = StringParameter("show-atoms")
 }
 
 trait ShowReferencesParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>

--- a/models/src/main/thrift/content/quiz.thrift
+++ b/models/src/main/thrift/content/quiz.thrift
@@ -1,0 +1,57 @@
+struct ResultGroup {
+  1: required string title
+  2: required string share
+  3: required i16 minScore
+}
+
+struct Asset {
+  1: required string type
+  /* what type is this? currently assuming opaque json */
+  2: required string data
+}
+
+struct Answer {
+  1: required string answerText
+  2: required list<Asset> assets
+  3: required i16 weight
+  4: optional string revealText
+}
+
+struct ResultBucket {
+  1: optional list<Asset> assets
+  2: required string description
+  3: required string title
+  4: required string share
+}
+
+struct ResultBuckets {
+  1: required list<ResultBucket> buckets
+}
+
+struct Question {
+  1: required string questionText
+  2: required list<Asset> assets
+  3: required list<Answer> answers
+}
+
+struct ResultGroups {
+  1: required list<ResultGroup> groups
+}
+
+struct QuizContent {
+  1: required list<Question> questions
+  2: optional ResultGroups resultGroups
+  3: optional ResultBuckets resultBuckets
+}
+
+struct QuizAtomData {
+  // do we need to store the ID, seeing as it is replicated(?) in the
+  // content-atom wrapping?
+  1  : required string id
+  2  : required string title
+  7  : required bool published
+  6  : required bool revealAtEnd
+  8  : required string quizType
+  9  : optional i16 defaultColumns
+  10 : required QuizContent content
+}

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1,5 +1,7 @@
 namespace scala com.gu.contentapi.client.model.v1
 
+include "quiz.thrift"
+
 struct CapiDateTime {
 
     /*
@@ -875,6 +877,18 @@ struct Tag {
     17: optional string twitterHandle
 }
 
+struct QuizAtom {
+  1: required string id
+  2: required list<string> labels // required, but may be empty
+  3: required string defaultHtml
+  4: required quiz.QuizAtomData data       // the atom payload
+//  6: required ContentChangeDetails contentChangeDetails
+ }
+
+/* an embedded content item with an independant lifecycle */
+struct Atoms {
+   1: optional QuizAtom quiz
+}
 
 struct Content {
 
@@ -977,6 +991,8 @@ struct Content {
     15: optional Rights rights
 
     16: optional Crossword crossword
+
+    17: optional Atoms atoms
 }
 
 struct Edition {


### PR DESCRIPTION
This incorporates the thrift from the content-atom repo and codifies the response (into which it is inserted) that CAPI will provide for an article with an embedded atom.

We don't need to do anything for the html body as that is just inserted into the existing field.

So this allows you to request a structured version of the atom with the `show-atoms` parameter.