### PR TITLE
Bump story packages model

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1,6 +1,4 @@
-include "event.thrift" # story-packages 
-# TODO rename the file in the story-packages-model project, 
-# as this will quickly lead to a name clash as we add more Thrift includes e.g. for atoms
+include "story_package_article.thrift"
 
 namespace scala com.gu.contentapi.client.model.v1
 
@@ -1082,7 +1080,7 @@ struct PackageArticle {
     /*
      * The story package metadata about the article. Includes custom kicker, etc.
      */
-    1: required event.Article metadata
+    1: required story_package_article.Article metadata
 
     /*
      * The content of the article.

--- a/project/build.scala
+++ b/project/build.scala
@@ -111,7 +111,7 @@ object ContentApiClientBuild extends Build {
       libraryDependencies ++= Seq(
         "org.apache.thrift" % "libthrift" % "0.9.2",
         "com.twitter" %% "scrooge-core" % "3.20.0",
-        "com.gu" %% "story-packages-model" % "0.3.1"
+        "com.gu" %% "story-packages-model" % "0.3.2"
       )
     )
 


### PR DESCRIPTION
The only change is that the Thrift file that we include now has a more
sensible name, less likely to cause clashes.