### PR TITLE
Add "audio" to content type enum

### DIFF
--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -17,7 +17,8 @@ enum ContentType {
     INTERACTIVE = 3,
     PICTURE = 4,
     VIDEO = 5,
-    CROSSWORD = 6
+    CROSSWORD = 6,
+    AUDIO = 7
 }
 
 /*


### PR DESCRIPTION
Just for fun, the ordinals are different from those in the Thrift file
for our internal models. This doesn't really matter because the values
get round-tripped to strings in between, but for our own sanity let's
try to keep the enums in sync from now on.