### PR TITLE
Build only for the last version of scala

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -64,7 +64,7 @@ object ContentApiClientBuild extends Build {
 
   val commonSettings = Seq(
     scalaVersion := "2.11.7",
-    crossScalaVersions := Seq("2.11.7", "2.10.5"),
+    crossScalaVersions := Seq("2.11.7"),
     releaseCrossBuild := true,
     releasePublishArtifactsAction := publishSigned.value,
     organization := "com.gu",


### PR DESCRIPTION
[content-atom](https://github.com/guardian/content-atom/) is currently not available for previous scala version so disable for the time being.