### PR TITLE
Add new tracking type tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.26
+* Add tracking tag type
+
 ## 7.25
 * Add embed elements support
 

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -134,7 +134,9 @@ enum TagType {
 
     TYPE = 7,
 
-    PUBLICATION = 8
+    PUBLICATION = 8,
+
+    TRACKING = 9
 
 }
 


### PR DESCRIPTION
Add the new tracking tag type.
Please note that the tags manager will not send them before the migration is over.

See:

- [Tags manager changes](https://github.com/guardian/tagmanager/pull/152)
- [Concierge changes](https://github.com/guardian/content-api/pull/1374)
- [Porter chnages] (https://github.com/guardian/content-api/pull/1375)