### PR TITLE
Update story package version to 1.0.2 in scala client

### DIFF
--- a/client/src/test/resources/templates/item-content-with-package.json
+++ b/client/src/test/resources/templates/item-content-with-package.json
@@ -15,6 +15,7 @@
     },
     "package": {
       "packageId": "I'm packing, I'm packing, I'm pack-pack-packing",
+      "packageName": "I am packing",
       "articles": [{
         "metadata": {
           "id": "internal-code/page/2436646",

--- a/client/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/parser/JsonParserItemTest.scala
@@ -523,6 +523,7 @@ class JsonParserItemTest extends FlatSpec with Matchers with OptionValues with C
   it should "deserialize a package correctly" in {
     val pkg = contentItemWithPackageResponse.`package`.value
     pkg.packageId should be("I'm packing, I'm packing, I'm pack-pack-packing")
+    pkg.packageName should be("I am packing")
     pkg.articles should have size 2
 
     pkg.articles(0).metadata.id should be("internal-code/page/2436646")

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1126,4 +1126,6 @@ struct Package {
     /* The articles in the package */
     2: required list<PackageArticle> articles
 
+    /* The package name */
+    3: required string packageName
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -114,7 +114,7 @@ test
       libraryDependencies ++= Seq(
         "org.apache.thrift" % "libthrift" % "0.9.2",
         "com.twitter" %% "scrooge-core" % "3.20.0",
-        "com.gu" %% "story-packages-model" % "0.4.0",
+        "com.gu" %% "story-packages-model" % "1.0.2",
         "com.gu" %% "content-atom-model" % "0.2.6"
       )
     )


### PR DESCRIPTION
[This is to support the new packageName field in the thrift model](https://github.com/guardian/story-packages-model/commit/ed1a614fcc0b0da704dc0047e6ed3ded2a90271d)
The scala-client actually uses the Package model defined in its own thrift model.