### PR TITLE
Scalaclient read thrift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.0
+* Add optional support (client-side) for processing thrift responses, together with json.
+  Howerver, thrift is NOT supported at the moment by Content Api; an upgrade of the Scala client will follow.
+* The following fields for item responses are now Scala Options: `results`, `relatedContent`,
+  `editorsPicks`, `mostViewed`, and `leadContent`.
+
 ## 7.30
 * Add show-stats parameter.
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ client.getResponse(allContentSearch) map { response =>
 }
 
 // print the web titles of the 15 most recent content items
-val lastTenSearch = SearchQuery().pageSize(15)
-client.getResponse(lastTenSearch) map { response =>
+val lastFifteenSearch = SearchQuery().pageSize(15)
+client.getResponse(lastFifteenSearch) map { response =>
   for (result <- response.results) println(result.webTitle)
 }
 

--- a/client/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/parser/JsonParser.scala
@@ -1,13 +1,29 @@
 package com.gu.contentapi.client.parser
 
+
+import com.gu.contentapi.client.model.v1.{SearchResponse => SearchResponseThrift}
+import com.gu.contentapi.client.model.v1.{ErrorResponse => ErrorResponseThrift}
+import com.gu.contentapi.client.model.v1.{ItemResponse => ItemResponseThrift}
+import com.gu.contentapi.client.model.v1.{TagsResponse => TagsResponseThrift}
+import com.gu.contentapi.client.model.v1.{EditionsResponse => EditionsResponseThrift}
+import com.gu.contentapi.client.model.v1.{SectionsResponse => SectionsResponseThrift}
+import com.gu.contentapi.client.model.v1.{RemovedContentResponse => RemovedContentResponseThrift}
 import com.gu.contentapi.client.model.v1._
+
+import com.gu.contentapi.client.model.ItemResponse
+import com.gu.contentapi.client.model.SearchResponse
+import com.gu.contentapi.client.model.RemovedContentResponse
+import com.gu.contentapi.client.model.TagsResponse
+import com.gu.contentapi.client.model.SectionsResponse
+import com.gu.contentapi.client.model.EditionsResponse
+import com.gu.contentapi.client.model.ErrorResponse
+
 import com.twitter.scrooge.ThriftEnum
 import org.joda.time.format.ISODateTimeFormat
 import org.joda.time.DateTime
 import org.json4s.{CustomSerializer, DefaultFormats}
 import org.json4s.JsonAST._
 import org.json4s.native.JsonMethods
-import com.gu.contentapi.client.model._
 import com.gu.storypackage.model.v1.{ArticleType, Group}
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.quiz._
@@ -21,34 +37,70 @@ object JsonParser {
     MembershipTierSerializer + OfficeSerializer + AssetTypeSerializer + ElementTypeSerializer +
     TagTypeSerializer + CrosswordTypeSerializer + StoryPackageArticleTypeSerializer + StoryPackageGroupSerializer
 
+  /*
+    We need to keep the all the old json parsers to keep the tests healthy;
+    however we're not using them anymore in the actual client. In the future, if we decide
+    to keep thrift only we can fix those test and delete the duplicate parsers below.
+   */
+
   def parseItem(json: String): ItemResponse = {
     (JsonMethods.parse(json) \ "response").transformField(fixFields).extract[ItemResponse]
+  }
+
+  def parseItemThrift(json: String): ItemResponseThrift = {
+    (JsonMethods.parse(json) \ "response").transformField(fixFields).extract[ItemResponseThrift]
   }
 
   def parseSearch(json: String): SearchResponse = {
     (JsonMethods.parse(json) \ "response").transformField(fixFields).extract[SearchResponse]
   }
 
+  def parseSearchThrift(json: String): SearchResponseThrift = {
+    (JsonMethods.parse(json) \ "response").transformField(fixFields).extract[SearchResponseThrift]
+  }
+
   def parseRemovedContent(json: String): RemovedContentResponse = {
     (JsonMethods.parse(json) \ "response").extract[RemovedContentResponse]
+  }
+
+  def parseRemovedContentThrift(json: String): RemovedContentResponseThrift = {
+    (JsonMethods.parse(json) \ "response").extract[RemovedContentResponseThrift]
   }
 
   def parseTags(json: String): TagsResponse = {
     (JsonMethods.parse(json) \ "response").extract[TagsResponse]
   }
 
+  def parseTagsThrift(json: String): TagsResponseThrift = {
+    (JsonMethods.parse(json) \ "response").extract[TagsResponseThrift]
+  }
+
   def parseSections(json: String): SectionsResponse = {
     (JsonMethods.parse(json) \ "response").extract[SectionsResponse]
+  }
+
+  def parseSectionsThrift(json: String): SectionsResponseThrift = {
+    (JsonMethods.parse(json) \ "response").extract[SectionsResponseThrift]
   }
 
   def parseEditions(json: String): EditionsResponse = {
     (JsonMethods.parse(json) \ "response").extract[EditionsResponse]
   }
 
+  def parseEditionsThrift(json: String): EditionsResponseThrift = {
+    (JsonMethods.parse(json) \ "response").extract[EditionsResponseThrift]
+  }
+
   def parseError(json: String): Option[ErrorResponse] = for {
     parsedJson <- JsonMethods.parseOpt(json)
     response = parsedJson \ "response"
     errorResponse <- response.extractOpt[ErrorResponse]
+  } yield errorResponse
+
+  def parseErrorThrift(json: String): Option[ErrorResponseThrift] = for {
+    parsedJson <- JsonMethods.parseOpt(json)
+    response = parsedJson \ "response"
+    errorResponse <- response.extractOpt[ErrorResponseThrift]
   } yield errorResponse
 
   def parseContent(json: String): Content = {

--- a/client/src/main/scala/com.gu.contentapi.client/parser/ThriftDeserializer.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/parser/ThriftDeserializer.scala
@@ -1,0 +1,18 @@
+package com.gu.contentapi.client.parser
+
+import java.io.ByteArrayInputStream
+
+import com.twitter.scrooge.{ThriftStruct, ThriftStructCodec}
+import org.apache.thrift.protocol.TCompactProtocol
+import org.apache.thrift.transport.TIOStreamTransport
+
+object ThriftDeserializer {
+
+  def deserialize[T <: ThriftStruct](responseBody: Array[Byte], codec: ThriftStructCodec[T]): T = {
+    val bbis = new ByteArrayInputStream(responseBody)
+    val transport = new TIOStreamTransport(bbis)
+    val protocol = new TCompactProtocol(transport)
+    codec.decode(protocol)
+  }
+}
+

--- a/client/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -1,7 +1,9 @@
 package com.gu.contentapi.client
 
 import com.gu.contentapi.client.model.v1.ContentType
-import com.gu.contentapi.client.model.{ErrorResponse, ItemQuery}
+
+import com.gu.contentapi.client.model.v1.{ErrorResponse => ErrorResponseThrift }
+import com.gu.contentapi.client.model.ItemQuery
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
@@ -23,7 +25,7 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
   it should "return errors as a broken promise" in {
     val query = ItemQuery("something-that-does-not-exist")
     val errorTest = api.getResponse(query) recover { case error =>
-      error should be (GuardianContentApiError(404, "Not Found", Some(ErrorResponse("error", "The requested resource could not be found."))))
+      error should be (GuardianContentApiThriftError(404, "Not Found", Some(ErrorResponseThrift("error", "The requested resource could not be found."))))
     }
     errorTest.futureValue
   }

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1147,3 +1147,191 @@ struct Package {
     /* The package name */
     3: required string packageName
 }
+
+struct ContentStats {
+
+    1: required i32 videos
+
+    2: required i32 images
+}
+
+/* These are experimental Responses structures */
+
+struct SearchResponse {
+
+    1: required string status
+
+    2: required string userTier
+
+    3: required i32 total
+
+    4: required i32 startIndex
+
+    5: required i32 pageSize
+
+    6: required i32 currentPage
+
+    7: required i32 pages
+
+    8: required string orderBy
+
+    9: required list<Content> results
+}
+
+struct ItemResponse {
+
+    1: required string status
+
+    2: required string userTier
+
+    3: optional i32 total
+
+    4: optional i32 startIndex
+
+    5: optional i32 pageSize
+
+    6: optional i32 currentPage
+
+    7: optional i32 pages
+
+    8: optional string orderBy
+
+    9: optional Content content
+
+    10: optional Tag tag
+
+    11: optional Edition edition
+
+    12: optional Section section
+
+    13: optional list<Content> results
+
+    14: optional contentatom.Atom quiz
+
+    15: optional list<Content> relatedContent
+
+    /* Old story packages */
+    16: optional list<Content> storyPackage
+
+    17: optional list<Content> editorsPicks
+
+    18: optional list<Content> mostViewed
+
+    19: optional list<Content> leadContent
+
+    /* New story packages */
+    20: optional list<Package> packages
+
+    21: optional list<contentatom.Atom> viewpoints
+}
+
+struct TagsResponse {
+
+    1: required string status
+
+    2: required string userTier
+
+    3: required i32 total
+
+    4: required i32 startIndex
+
+    5: required i32 pageSize
+
+    6: required i32 currentPage
+
+    7: required i32 pages
+
+    8: required list<Tag> results
+}
+
+struct SectionsResponse {
+
+    1: required string status
+
+    2: required string userTier
+
+    3: required i32 total
+
+    4: required list<Section> results
+}
+
+struct EditionsResponse {
+
+    1: required string status
+
+    2: required string userTier
+
+    3: required i32 total
+
+    4: required list<NetworkFront> results
+}
+
+struct AtomsResponse {
+
+    1: required string status
+
+    2: required string userTier
+
+    3: required i32 total
+
+    4: required i32 startIndex
+
+    5: required i32 pageSize
+
+    6: required i32 currentPage
+
+    7: required i32 pages
+
+    8: required list<Atoms> results
+}
+
+struct PackageResponse {
+
+    1: required string status
+
+    2: required string userTier
+
+    3: required i32 total
+
+    4: required i32 startIndex
+
+    5: required i32 pageSize
+
+    6: required i32 currentPage
+
+    7: required i32 pages
+
+    8: required string orderBy
+
+    9: required list<Package> results
+}
+
+struct RemovedContentResponse {
+
+    1: required string status
+
+    2: required string userTier
+
+    3: required i32 total
+
+    4: required i32 startIndex
+
+    5: required i32 pageSize
+
+    6: required i32 currentPage
+
+    7: required i32 pages
+
+    8: required string orderBy
+
+    9: required list<string> results
+}
+
+struct ErrorResponse {
+
+    1: required string status
+
+    2: required string message
+}
+
+

--- a/models/src/main/thrift/content/v1.thrift
+++ b/models/src/main/thrift/content/v1.thrift
@@ -1148,14 +1148,8 @@ struct Package {
     3: required string packageName
 }
 
-struct ContentStats {
 
-    1: required i32 videos
-
-    2: required i32 images
-}
-
-/* These are experimental Responses structures */
+/* These are Responses structures shared with the Content API */
 
 struct SearchResponse {
 


### PR DESCRIPTION
Let the Scala Client read Thrift from Concierge! 

I tested this locally and works well, but before merging I will add tests to the PR. The Concierge PR is on its way.

There are a lot of things called *-Thrift for now; if we decide to go all in with Thrift after a period of testing I'll rename everything, but for now is a good way to keep things separate.