### PR TITLE
Add tests for thrift responses

### DIFF
--- a/client/src/test/scala/com.gu.contentapi.client/ClientTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/ClientTest.scala
@@ -7,6 +7,7 @@ import com.google.common.io.Resources
 trait ClientTest {
 
   val api = new GuardianContentClient("test")
+  val apiThrift = new GuardianContentClient("test", useThrift = true)
 
   def loadJson(filename: String): String = {
     Resources.toString(Resources.getResource(s"templates/$filename"), StandardCharsets.UTF_8)

--- a/client/src/test/scala/com.gu.contentapi.client/utils/GuardianContentClientThriftTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/utils/GuardianContentClientThriftTest.scala
@@ -1,0 +1,74 @@
+package com.gu.contentapi.client
+
+import com.gu.contentapi.client.model.v1.ContentType
+
+import com.gu.contentapi.client.model.v1.{ErrorResponse => ErrorResponseThrift }
+import com.gu.contentapi.client.model.ItemQuery
+import org.joda.time.DateTime
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Seconds, Span}
+import org.scalatest.{OptionValues, FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class GuardianContentClientThriftTest extends FlatSpec with Matchers with ClientTest with ScalaFutures with OptionValues {
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(2, Seconds))
+
+  "client interface" should "successfully call the Content API" in {
+    val query = ItemQuery("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
+    val content = for {
+      response <- apiThrift.getResponse(query)
+    } yield response.content.get
+    content.futureValue.id should be ("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
+  }
+
+  it should "return errors as a broken promise" in {
+    val query = ItemQuery("something-that-does-not-exist")
+    val errorTest = apiThrift.getResponse(query) recover { case error =>
+      error should be (GuardianContentApiThriftError(404, "Not Found", Some(ErrorResponseThrift("error", "The requested resource could not be found."))))
+    }
+    errorTest.futureValue
+  }
+
+  it should "correctly add API key to request" in {
+    apiThrift.url("location", Map.empty) should include(s"api-key=${apiThrift.apiKey}")
+  }
+
+  it should "understand custom parameters" in {
+    val now = new DateTime
+    val params = apiThrift.search
+      .stringParam("aStringParam", "foo")
+      .intParam("aIntParam", 3)
+      .dateParam("aDateParam", now)
+      .boolParam("aBoolParam", true)
+      .parameters
+
+    params.get("aStringParam") should be (Some("foo"))
+    params.get("aIntParam") should be (Some("3"))
+    params.get("aDateParam") should be (Some(now.toString()))
+    params.get("aBoolParam") should be (Some("true"))
+  }
+
+  it should "perform a given item query" in {
+    val query = ItemQuery("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
+    val content = for (response <- apiThrift.getResponse(query)) yield response.content.get
+    content.futureValue.id should be ("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")
+  }
+
+  it should "perform a given removed content query" in {
+    val query = apiThrift.removedContent.reason("expired")
+    val results = for (response <- apiThrift.getResponse(query)) yield response.results
+    val fResults = results.futureValue
+    fResults.size should be (10)
+  }
+
+  it should "perform a given search query using the type filter" in {
+    val query = apiThrift.search.contentType("article")
+    val results = for (response <- apiThrift.getResponse(query)) yield response.results
+    val fResults = results.futureValue
+    fResults.size should be (10)
+    fResults.map(_.`type` should be(ContentType.Article))
+  }
+
+}
+


### PR DESCRIPTION
Now that Concierge serves thrift, I added the tests for the Scala Client. For now they are a duplication of the tests we already had, but consuming thrift instead of json.