### PR TITLE
We now publish the models to Maven Central, not Bintray/JCenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 * Split the models into a separate library.
 
-Note that the content-api-client now depends on an artifact that is published to [JCenter](https://bintray.com/bintray/jcenter), not Maven Central. This means you will need the JCenter resolver to be enabled in sbt. If you are using sbt 0.13.11, you may need to add the following line to your sbt config:
-
-```
-useJCenter := true
-```
-
 ## 8.1 
 * Add `contains-element` filter. e.g. contains-element=video
 * Add `commentable` filter.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ A Scala client for the Guardian's [Content API] (http://explorer.capi.gutools.co
 
 ## Setup
 
-Add the following lines to your SBT build definition, and set the version number to be the latest from the [releases page] (https://github.com/guardian/content-api-scala-client/releases):
+Add the following line to your SBT build definition, and set the version number to be the latest from the [releases page] (https://github.com/guardian/content-api-scala-client/releases):
 
 ```scala
-useJCenter := true,
 libraryDependencies += "com.gu" %% "content-api-client" % "x.y"
 ```
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -78,7 +78,6 @@ object ContentApiClientBuild extends Build {
       )),
       javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
       scalacOptions ++= Seq("-deprecation", "-unchecked"),
-      resolvers += Resolver.bintrayRepo("guardian", "platforms"),
       releaseProcess := Seq(
         checkSnapshotDependencies,
         inquireVersions,
@@ -97,7 +96,7 @@ object ContentApiClientBuild extends Build {
       buildInfoPackage := "com.gu.contentapi.buildinfo",
       buildInfoObject := "CapiBuildInfo",
       libraryDependencies ++= Seq(
-        "com.gu" % "content-api-models" % "8.1.1",
+        "com.gu" % "content-api-models" % "8.1.2",
         "org.apache.thrift" % "libthrift" % "0.9.2",
         "com.twitter" %% "scrooge-core" % "3.20.0",
         "org.json4s" %% "json4s-native" % "3.3.0",


### PR DESCRIPTION
Get rid of all the notes about `useJCenter` and remove the unneeded resolver.