### PR TITLE
Rename everything without the -thrift suffix.

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -3,13 +3,13 @@ package com.gu.contentapi.client
 import java.nio.charset.StandardCharsets
 
 import com.gu.contentapi.client.model._
-import com.gu.contentapi.client.model.v1.{SearchResponse => SearchResponseThrift}
-import com.gu.contentapi.client.model.v1.{ErrorResponse => ErrorResponseThrift}
-import com.gu.contentapi.client.model.v1.{ItemResponse => ItemResponseThrift}
-import com.gu.contentapi.client.model.v1.{TagsResponse => TagsResponseThrift}
-import com.gu.contentapi.client.model.v1.{EditionsResponse => EditionsResponseThrift}
-import com.gu.contentapi.client.model.v1.{SectionsResponse => SectionsResponseThrift}
-import com.gu.contentapi.client.model.v1.{RemovedContentResponse => RemovedContentResponseThrift}
+import com.gu.contentapi.client.model.v1.SearchResponse
+import com.gu.contentapi.client.model.v1.ErrorResponse
+import com.gu.contentapi.client.model.v1.ItemResponse
+import com.gu.contentapi.client.model.v1.TagsResponse
+import com.gu.contentapi.client.model.v1.EditionsResponse
+import com.gu.contentapi.client.model.v1.SectionsResponse
+import com.gu.contentapi.client.model.v1.RemovedContentResponse
 
 import com.gu.contentapi.client.parser.JsonParser
 
@@ -24,7 +24,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import com.gu.contentapi.client.parser.ThriftDeserializer
 
 case class GuardianContentApiError(httpStatus: Int, httpMessage: String, errorResponse: Option[ErrorResponse] = None) extends Exception(httpMessage)
-case class GuardianContentApiThriftError(httpStatus: Int, httpMessage: String, errorResponse: Option[ErrorResponseThrift] = None) extends Exception(httpMessage)
 
 trait ContentApiClientLogic {
   val apiKey: String
@@ -80,9 +79,9 @@ trait ContentApiClientLogic {
     }
   }
 
-  private def contentApiError(response: HttpResponse): GuardianContentApiThriftError = {
-    if (useThrift) GuardianContentApiThriftError(response.statusCode, response.statusMessage, Some(ThriftDeserializer.deserialize(response.body, ErrorResponseThrift)))
-    else GuardianContentApiThriftError(response.statusCode, response.statusMessage, JsonParser.parseErrorThrift(new String(response.body, "UTF-8")))
+  private def contentApiError(response: HttpResponse): GuardianContentApiError = {
+    if (useThrift) GuardianContentApiError(response.statusCode, response.statusMessage, Some(ThriftDeserializer.deserialize(response.body, ErrorResponse)))
+    else GuardianContentApiError(response.statusCode, response.statusMessage, JsonParser.parseErrorThrift(new String(response.body, "UTF-8")))
   }
 
   protected def get(url: String, headers: Map[String, String])(implicit context: ExecutionContext): Future[HttpResponse] = {
@@ -103,39 +102,39 @@ trait ContentApiClientLogic {
 
   /* Exposed API */
 
-  def getResponse(itemQuery: ItemQuery)(implicit context: ExecutionContext): Future[ItemResponseThrift] =
+  def getResponse(itemQuery: ItemQuery)(implicit context: ExecutionContext): Future[ItemResponse] =
     fetchResponse(itemQuery) map { response =>
-      if (useThrift) ThriftDeserializer.deserialize(response, ItemResponseThrift)
+      if (useThrift) ThriftDeserializer.deserialize(response, ItemResponse)
       else JsonParser.parseItemThrift(new String(response, StandardCharsets.UTF_8))
     }
 
-  def getResponse(searchQuery: SearchQuery)(implicit context: ExecutionContext): Future[SearchResponseThrift] =
+  def getResponse(searchQuery: SearchQuery)(implicit context: ExecutionContext): Future[SearchResponse] =
     fetchResponse(searchQuery) map { response =>
-      if (useThrift) ThriftDeserializer.deserialize(response, SearchResponseThrift)
+      if (useThrift) ThriftDeserializer.deserialize(response, SearchResponse)
       else JsonParser.parseSearchThrift(new String(response, StandardCharsets.UTF_8))
     }
 
-  def getResponse(tagsQuery: TagsQuery)(implicit context: ExecutionContext): Future[TagsResponseThrift] =
+  def getResponse(tagsQuery: TagsQuery)(implicit context: ExecutionContext): Future[TagsResponse] =
     fetchResponse(tagsQuery) map { response =>
-      if (useThrift) ThriftDeserializer.deserialize(response, TagsResponseThrift)
+      if (useThrift) ThriftDeserializer.deserialize(response, TagsResponse)
       else JsonParser.parseTagsThrift(new String(response, StandardCharsets.UTF_8))
     }
 
-  def getResponse(sectionsQuery: SectionsQuery)(implicit context: ExecutionContext): Future[SectionsResponseThrift] =
+  def getResponse(sectionsQuery: SectionsQuery)(implicit context: ExecutionContext): Future[SectionsResponse] =
     fetchResponse(sectionsQuery) map { response =>
-      if (useThrift) ThriftDeserializer.deserialize(response, SectionsResponseThrift)
+      if (useThrift) ThriftDeserializer.deserialize(response, SectionsResponse)
       else JsonParser.parseSectionsThrift(new String(response, StandardCharsets.UTF_8))
     }
 
-  def getResponse(editionsQuery: EditionsQuery)(implicit context: ExecutionContext): Future[EditionsResponseThrift] =
+  def getResponse(editionsQuery: EditionsQuery)(implicit context: ExecutionContext): Future[EditionsResponse] =
     fetchResponse(editionsQuery) map { response =>
-      if (useThrift) ThriftDeserializer.deserialize(response, EditionsResponseThrift)
+      if (useThrift) ThriftDeserializer.deserialize(response, EditionsResponse)
       else JsonParser.parseEditionsThrift(new String(response, StandardCharsets.UTF_8))
     }
 
-  def getResponse(removedContentQuery: RemovedContentQuery)(implicit context: ExecutionContext): Future[RemovedContentResponseThrift] =
+  def getResponse(removedContentQuery: RemovedContentQuery)(implicit context: ExecutionContext): Future[RemovedContentResponse] =
     fetchResponse(removedContentQuery) map { response =>
-      if (useThrift) ThriftDeserializer.deserialize(response, RemovedContentResponseThrift)
+      if (useThrift) ThriftDeserializer.deserialize(response, RemovedContentResponse)
       else JsonParser.parseRemovedContentThrift(new String(response, StandardCharsets.UTF_8))
     }
 

--- a/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -2,7 +2,7 @@ package com.gu.contentapi.client
 
 import com.gu.contentapi.client.model.v1.ContentType
 
-import com.gu.contentapi.client.model.v1.{ErrorResponse => ErrorResponseThrift }
+import com.gu.contentapi.client.model.v1.ErrorResponse
 import com.gu.contentapi.client.model.ItemQuery
 import org.joda.time.DateTime
 import org.scalatest.concurrent.ScalaFutures
@@ -25,7 +25,7 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest w
   it should "return errors as a broken promise" in {
     val query = ItemQuery("something-that-does-not-exist")
     val errorTest = api.getResponse(query) recover { case error =>
-      error should be (GuardianContentApiThriftError(404, "Not Found", Some(ErrorResponseThrift("error", "The requested resource could not be found."))))
+      error should be (GuardianContentApiError(404, "Not Found", Some(ErrorResponse("error", "The requested resource could not be found."))))
     }
     errorTest.futureValue
   }

--- a/src/test/scala/com.gu.contentapi.client/utils/GuardianContentClientThriftTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/utils/GuardianContentClientThriftTest.scala
@@ -25,7 +25,7 @@ class GuardianContentClientThriftTest extends FlatSpec with Matchers with Client
   it should "return errors as a broken promise" in {
     val query = ItemQuery("something-that-does-not-exist")
     val errorTest = apiThrift.getResponse(query) recover { case error =>
-      error should be (GuardianContentApiThriftError(404, "Not Found", Some(ErrorResponseThrift("error", "The requested resource could not be found."))))
+      error should be (GuardianContentApiError(404, "Not Found", Some(ErrorResponseThrift("error", "The requested resource could not be found."))))
     }
     errorTest.futureValue
   }


### PR DESCRIPTION
When I was migrating the Scala Client to use thrift I had to rename all the classes to `somethingThrift` to make them co-exist with the old ones. Now that the migration is complete this isn't necessary anymore, so I changed all the names back to what they were.

This should also fix the issue reported by David, where having `GuardianContentApiError` hanging around was causing runtime issues.

CC @LATaylor-guardian and @davidfurey 