### PR TITLE
Bump the CAPI models and downgrade libthrift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.7
+* Bump the content-api-models dependency
+* Downgrade libthrift from 0.9.3 to 0.9.1
+
 ## 8.6
 * Use content-api-models-json for JSON parsing
 

--- a/build.sbt
+++ b/build.sbt
@@ -76,10 +76,13 @@ releaseProcess := Seq(
 buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
+
+val CapiModelsVersion = "8.8"
+
 libraryDependencies ++= Seq(
-  "com.gu" % "content-api-models" % "8.6",
-  "com.gu" % "content-api-models-json" % "8.6",
-  "org.apache.thrift" % "libthrift" % "0.9.3",
+  "com.gu" % "content-api-models" % CapiModelsVersion,
+  "com.gu" % "content-api-models-json" % CapiModelsVersion,
+  "org.apache.thrift" % "libthrift" % "0.9.1",
   "com.twitter" %% "scrooge-core" % "4.6.0",
   "org.json4s" %% "json4s-native" % "3.3.0",
   "org.json4s" %% "json4s-ext" % "3.3.0",

--- a/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.{OptionValues, FlatSpec, Matchers}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class GuardianContentClientTest extends FlatSpec with Matchers with ClientTest with ScalaFutures with OptionValues {
-  implicit override val patienceConfig = PatienceConfig(timeout = Span(2, Seconds))
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds))
 
   "client interface" should "successfully call the Content API" in {
     val query = ItemQuery("commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry")


### PR DESCRIPTION
See guardian/content-api-models#10 for the reason behind downgrading libthrift