### PR TITLE
Bump capi models version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 9.4
-* Bump the content-api-models dependency
+* Bump the content-api-models dependency adding campaignColour and isMandatory
 
 ## 9.3
 * add `internalShortId`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.4
+* Bump the content-api-models dependency
+
 ## 9.3
 * add `internalShortId`
 * add missing circe decoders

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "9.12"
+val CapiModelsVersion = "9.14"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
Bumped 2 versions intentionally as 2 changes have been made to the Capi Model in quick succession and this means that the scala client only needs to be re-released once