### PR TITLE
Use content-api-models v10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "9.24"
+val CapiModelsVersion = "10.0"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
This is the version with circe-only. It shouldn't have any effect on the scala-client - I'll try it with crier first.