### PR TITLE
Bump content-api-models to v10.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "10.3"
+val CapiModelsVersion = "10.5"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
This is purely to keep the versions in sync - content-api-client is currently on 10.4