### PR TITLE
Bump content-api-models to 10.16 for film review atom support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "10.14"
+val CapiModelsVersion = "10.16"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
https://github.com/guardian/content-api-models/pull/82