### PR TITLE
Bump content-api-models ot 10.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.17
+* `genre` field is now a list (content-api-model 10.17)
+
 ## 10.16
 * Support film review atoms (content-api-model 10.16)
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "10.16"
+val CapiModelsVersion = "10.17"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
https://github.com/guardian/content-api-models/pull/84