### PR TITLE
Bump content-api-models to 10.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 10.22
+* Upgrade content-api-models dependency (refactored circe macros)
+
 ## 10.21
 * Upgraded Circe to 0.6.1.
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "10.21"
+val CapiModelsVersion = "10.22"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
https://github.com/guardian/content-api-models/pull/88