### PR TITLE
Bump content-api-models to 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.0
+* Upgrade content-api-models dependency to 11 (fezziwig dependency)
+
 ## 10.24
 * Upgrade content-api-models dependency to include sourceArticleId field in recipe and review atom types.
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "10.24"
+val CapiModelsVersion = "11.0"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
Major version jump for [fezziwig dependency](https://github.com/guardian/content-api-models/pull/92)