### PR TITLE
Content API Scala Client - Add support for additional endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.3
+* Provide ability to query recipe, review and atom endpoints for internal clients.
+
 ## 11.2
 * Upgrade content-api-models dependency to 11.2 (upgrades circe to 0.7.0)
 

--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -1,10 +1,7 @@
 package com.gu.contentapi.client
 
-import java.nio.charset.StandardCharsets
-
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1._
-
 import com.gu.contentapi.client.utils.QueryStringParams
 import com.ning.http.client.AsyncHttpClientConfig.Builder
 import com.ning.http.client.AsyncHttpClient
@@ -47,9 +44,16 @@ trait ContentApiClientLogic {
   def item(id: String) = ItemQuery(id)
   val search = SearchQuery()
   val tags = TagsQuery()
-  val sections = new SectionsQuery()
+  val sections = SectionsQuery()
   val editions = EditionsQuery()
   val removedContent = RemovedContentQuery()
+  val atoms = AtomsQuery()
+  val recipes = RecipesQuery()
+  val reviews = ReviewsQuery()
+  val gameReviews = GameReviewsQuery()
+  val restaurantReviews = RestaurantReviewsQuery()
+  val filmReviews = FilmReviewsQuery()
+  val videoStats = VideoStatsQuery()
 
   case class HttpResponse(body: Array[Byte], statusCode: Int, statusMessage: String)
 
@@ -123,6 +127,36 @@ trait ContentApiClientLogic {
   def getResponse(videoStatsQuery: VideoStatsQuery)(implicit context: ExecutionContext): Future[VideoStatsResponse] =
     fetchResponse(videoStatsQuery) map { response =>
       ThriftDeserializer.deserialize(response, VideoStatsResponse)
+    }
+
+  def getResponse(atomsQuery: AtomsQuery)(implicit context: ExecutionContext): Future[AtomsResponse] =
+    fetchResponse(atomsQuery) map { response =>
+      ThriftDeserializer.deserialize(response, AtomsResponse)
+    }
+
+  def getResponse(recipesQuery: RecipesQuery)(implicit context: ExecutionContext): Future[AtomsResponse] =
+    fetchResponse(recipesQuery) map { response =>
+      ThriftDeserializer.deserialize(response, AtomsResponse)
+    }
+
+  def getResponse(reviewsQuery: ReviewsQuery)(implicit context: ExecutionContext): Future[AtomsResponse] =
+    fetchResponse(reviewsQuery) map { response =>
+      ThriftDeserializer.deserialize(response, AtomsResponse)
+    }
+
+  def getResponse(gameReviewsQuery: GameReviewsQuery)(implicit context: ExecutionContext): Future[AtomsResponse] =
+    fetchResponse(gameReviewsQuery) map { response =>
+      ThriftDeserializer.deserialize(response, AtomsResponse)
+    }
+
+  def getResponse(restaurantReviewsQuery: RestaurantReviewsQuery)(implicit context: ExecutionContext): Future[AtomsResponse] =
+    fetchResponse(restaurantReviewsQuery) map { response =>
+      ThriftDeserializer.deserialize(response, AtomsResponse)
+    }
+
+  def getResponse(filmReviewsQuery: FilmReviewsQuery)(implicit context: ExecutionContext): Future[AtomsResponse] =
+    fetchResponse(filmReviewsQuery) map { response =>
+      ThriftDeserializer.deserialize(response, AtomsResponse)
     }
 
   /**

--- a/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -20,7 +20,8 @@ case class ItemQuery(id: String, parameterHolder: Map[String, Parameter] = Map.e
   with ShowReferencesParameters[ItemQuery]
   with ShowExtendedParameters[ItemQuery]
   with PaginationParameters[ItemQuery]
-  with OrderingParameters[ItemQuery]
+  with OrderByParameter[ItemQuery]
+  with UseDateParameter[ItemQuery]
   with FilterParameters[ItemQuery]
   with FilterExtendedParameters[ItemQuery]
   with FilterSearchParameters[ItemQuery] {
@@ -37,7 +38,8 @@ case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty)
   extends ContentApiQuery
   with ShowParameters[SearchQuery]
   with ShowReferencesParameters[SearchQuery]
-  with OrderingParameters[SearchQuery]
+  with OrderByParameter[SearchQuery]
+  with UseDateParameter[SearchQuery]
   with PaginationParameters[SearchQuery]
   with FilterParameters[SearchQuery]
   with FilterExtendedParameters[SearchQuery]
@@ -51,7 +53,8 @@ case class RemovedContentQuery(parameterHolder: Map[String, Parameter] = Map.emp
   extends ContentApiQuery
   with RemovedReasonParameters[RemovedContentQuery]
   with PaginationParameters[RemovedContentQuery]
-  with OrderingParameters[RemovedContentQuery] {
+  with OrderByParameter[RemovedContentQuery]
+  with UseDateParameter[RemovedContentQuery]{
 
   def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
 
@@ -101,6 +104,71 @@ case class VideoStatsQuery(
   override def pathSegment: String = Seq(Some("stats/videos"), edition, section).flatten.mkString("/")
 }
 
+case class AtomsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ContentApiQuery
+  with AtomsParameters[AtomsQuery]
+  with PaginationParameters[AtomsQuery]
+  with OrderByParameter[AtomsQuery]
+  with FilterSearchParameters[AtomsQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+
+  override def pathSegment: String = "atoms"
+}
+
+case class RecipesQuery(parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ContentApiQuery
+  with PaginationParameters[RecipesQuery]
+  with RecipeParameters[RecipesQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+
+  override def pathSegment: String = "atoms/recipes"
+}
+
+case class ReviewsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ContentApiQuery
+  with PaginationParameters[ReviewsQuery]
+  with ReviewSpecificParameters[ReviewsQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+
+  override def pathSegment: String = "atoms/reviews"
+}
+
+case class GameReviewsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ContentApiQuery
+    with ReviewSpecificParameters[GameReviewsQuery]
+    with PaginationParameters[GameReviewsQuery]
+    with GameParameters[GameReviewsQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+
+  override def pathSegment: String = "atoms/reviews/game"
+}
+
+case class RestaurantReviewsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ContentApiQuery
+    with ReviewSpecificParameters[RestaurantReviewsQuery]
+    with PaginationParameters[RestaurantReviewsQuery]
+    with RestaurantParameters[RestaurantReviewsQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+
+  override def pathSegment: String = "atoms/reviews/restaurant"
+}
+
+case class FilmReviewsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ContentApiQuery
+    with ReviewSpecificParameters[FilmReviewsQuery]
+    with PaginationParameters[FilmReviewsQuery]
+    with FilmParameters[FilmReviewsQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+
+  override def pathSegment: String = "atoms/reviews/film"
+}
+
 trait EditionParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
   def edition = StringParameter("edition")
 }
@@ -133,8 +201,11 @@ trait PaginationParameters[Owner <: Parameters[Owner]] extends Parameters[Owner]
   def pageSize = IntParameter("page-size")
 }
 
-trait OrderingParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+trait OrderByParameter[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
   def orderBy = StringParameter("order-by")
+}
+
+trait UseDateParameter[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
   def useDate = StringParameter("use-date")
 }
 
@@ -172,4 +243,43 @@ trait FilterSearchParameters[Owner <: Parameters[Owner]] extends Parameters[Owne
 // Supports values gone, expired and takendown.
 trait RemovedReasonParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
   def reason = StringParameter("reason")
+}
+
+trait AtomsParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def types = StringParameter("types")
+  def searchFields = StringParameter("searchFields")
+  def fromDate = DateParameter("from-date")
+  def toDate = DateParameter("to-date")
+}
+
+trait RecipeParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def title = StringParameter("title")
+  def credits = StringParameter("credits")
+  def categories = StringParameter("category")
+  def cuisines = StringParameter("cuisine")
+  def dietary = StringParameter("dietary")
+  def celebration = StringParameter("celebration")
+  def ingredients = StringParameter("ingredients")
+  def maxTime = IntParameter("max-time")
+}
+
+trait ReviewSpecificParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def reviewer = StringParameter("reviewer")
+  def maxRating = IntParameter("max-rating")
+  def minRating = IntParameter("min-rating")
+}
+
+trait FilmParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def name = StringParameter("name")
+  def genres = StringParameter("genres")
+  def actors = StringParameter("actors")
+  def directors = StringParameter("directors")
+}
+
+trait GameParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def gameName = StringParameter("name")
+}
+
+trait RestaurantParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def restaurantName = StringParameter("name")
 }


### PR DESCRIPTION
Adding support for:
     - Recipe endpoint and supported parameters.
     - Review endpoint and supported parameters along with specfic cases for games, restaurants and films.
     - Atoms endpoint (this was missing suprisingly, I expect because of no use cases from Scala projects internally)

I've added some basic tests for these in line with the project.

Note: I've made a corresponding change to Concierge which will only make the use of the above permissable if the user provides an internal key.