### PR TITLE
Content-api-models 11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.2
+* Upgrade content-api-models dependency to 11.2 (upgrades circe to 0.7.0)
+
 ## 11.1
 * Upgrade content api models dependency to 11.1 to provide images on reviews model.
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "11.1"
+val CapiModelsVersion = "11.2"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
The corresponding [capi-models change](https://github.com/guardian/content-api-models/pull/94) bumped circe to 0.7.0