### PR TITLE
Bump models to 11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.6
+* Update content-api-models to 11.6 (adds categories + entityIds fields to Tag model)
+
 ## 11.5
 * Add storyquestions field to item response.
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "11.5"
+val CapiModelsVersion = "11.6"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
Adds categories/entityIds to Tag model - https://github.com/guardian/content-api-models/pull/96