### PR TITLE
Bump models to 11.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.19
+* Update content-api-models to 11.19 (rename qanda fields)
+
 ## 11.17
 * Update content-api-models to 11.17 (add shouldHideReaderRevenue field)
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "11.17"
+val CapiModelsVersion = "11.19"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % CapiModelsVersion,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "11.18-SNAPSHOT"
+version in ThisBuild := "11.19-SNAPSHOT"


### PR DESCRIPTION
https://github.com/guardian/content-api-models/pull/112