### PR TITLE
scala 2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.24
+* Update content-api-models to 11.24 (scala 2.12.3)
+* This is the first version available for both scala `2.12.x` and scala `2.11.x`
+
 ## 11.23
 * Update content-api-models to 11.23 (add closeDate field to story questions atom)
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,8 @@ publishMavenStyle := true
 publishArtifact in Test := false
 pomIncludeRepository := { _ => false }
 description := "Scala client for the Guardian's Content API"
-scalaVersion := "2.11.11"
+scalaVersion := "2.12.3"
+crossScalaVersions := Seq("2.11.11", scalaVersion.value)
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 organization := "com.gu"
 licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
@@ -79,13 +80,13 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "11.23"
+val CapiModelsVersion = "11.24"
 
 libraryDependencies ++= Seq(
-  "com.gu" % "content-api-models-scala" % CapiModelsVersion,
+  "com.gu" %% "content-api-models-scala" % CapiModelsVersion,
   "joda-time" % "joda-time" % "2.3",
-  "net.databinder.dispatch" %% "dispatch-core" % "0.11.3",
-  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+  "net.databinder.dispatch" %% "dispatch-core" % "0.13.1",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "com.google.guava" % "guava" % "19.0" % "test"
 )
 

--- a/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -3,8 +3,6 @@ package com.gu.contentapi.client
 import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1._
 import com.gu.contentapi.client.utils.QueryStringParams
-import com.ning.http.client.AsyncHttpClientConfig.Builder
-import com.ning.http.client.AsyncHttpClient
 import dispatch.{FunctionHandler, Http}
 import com.gu.contentapi.buildinfo.CapiBuildInfo
 
@@ -20,13 +18,8 @@ trait ContentApiClientLogic {
 
   protected val userAgent = "content-api-scala-client/"+CapiBuildInfo.version
 
-  protected lazy val http = {
-    /*
-    Warning: do not call `Http.configure(...)` because it leaks resources!
-    See https://github.com/dispatch/reboot/pull/115
-     */
-    val config = new Builder()
-      .setAllowPoolingConnections(true)
+  protected lazy val http = Http.withConfiguration { config =>
+    config
       .setMaxConnectionsPerHost(10)
       .setMaxConnections(10)
       .setConnectTimeout(1000)
@@ -34,9 +27,7 @@ trait ContentApiClientLogic {
       .setCompressionEnforced(true)
       .setFollowRedirect(true)
       .setUserAgent(userAgent)
-      .setConnectionTTL(60000) // to respect DNS TTLs
-      .build()
-    Http(new AsyncHttpClient(config))
+      .setConnectionTtl(60000) // to respect DNS TTLs
   }
 
   val targetUrl = "http://content.guardianapis.com"


### PR DESCRIPTION
Only major change here is the `dispatch` version. The comment about leaky resources is no longer relevant thanks to Chris B https://github.com/dispatch/reboot/pull/118