### PR TITLE
content-api-models 11.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.25
+* Update content-api-models to 11.25 (add Atom updates to the crier event model)
+
 ## 11.24
 * Update content-api-models to 11.24 (scala 2.12.3)
 * This is the first version available for both scala `2.12.x` and scala `2.11.x`

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "11.24"
+val CapiModelsVersion = "11.25"
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
To add atoms to crier event model - https://github.com/guardian/content-api-models/pull/117/files