### PR TITLE
Add supported `sponsorship-type` filter for Section and bump capi models.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.27
+* Update content-api-models to 11.26 (add validTo and validFrom dates to Sponsorship, present in both tags and sections.)
+* Add supported `sponsorship-type` filter for Section.
+
 ## 11.25
 * Update content-api-models to 11.25 (add Atom updates to the crier event model)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 11.27
+## 11.28
 * Update content-api-models to 11.26 (add validTo and validFrom dates to Sponsorship, present in both tags and sections.)
 * Add supported `sponsorship-type` filter for Section.
 

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "11.27"
+val CapiModelsVersion = "11.28"
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % CapiModelsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "11.25"
+val CapiModelsVersion = "11.27"
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % CapiModelsVersion,

--- a/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -76,7 +76,8 @@ case class TagsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
 
 case class SectionsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
   extends ContentApiQuery
-  with FilterSearchParameters[SectionsQuery] {
+  with FilterSearchParameters[SectionsQuery]
+  with FilterSectionParameters[SectionsQuery]{
 
   def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
 
@@ -248,6 +249,10 @@ trait FilterExtendedParameters[Owner <: Parameters[Owner]] extends Parameters[Ow
 
 trait FilterTagParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
   def tagType = StringParameter("type")
+}
+
+trait FilterSectionParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  def sponsorshipType = StringParameter("sponsorship-type")
 }
 
 trait FilterSearchParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>

--- a/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
@@ -17,6 +17,10 @@ class ContentApiQueryTest extends FlatSpec with Matchers  {
     SectionsQuery().toString shouldEqual "SectionsQuery(/sections)"
   }
 
+  "SectionsQuery.toString" should "add sponsorship-type filter" in {
+    SectionsQuery().sponsorshipType("paid-content").toString shouldEqual "SectionsQuery(/sections?sponsorship-type=paid-content)"
+  }
+
   "TagsQuery.toString" should "be awesome" in {
     TagsQuery().tagType("contributor").toString shouldEqual "TagsQuery(/tags?type=contributor)"
   }


### PR DESCRIPTION
Won't compile until https://github.com/guardian/content-api-models/pull/122 is released.
