### PR TITLE
CapiModelsVersion - Bump version due to adding sponsorship to Rich Links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.35
+* Update content-api-models to 11.35 (add sponsorship information to rich link fields)
+
 ## 11.33
 * Move to using OkHTTP over Dispatch
 

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "11.33"
+val CapiModelsVersion = "11.35"
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
Update content-api-models to 11.35 (add sponsorship information to rich link fields)