### PR TITLE
Nb port content type enrichment from capi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 11.43 
-
+* Update content-api-models to 11.43 (new embargo field on atoms)
 * Adds an implicit designType field to Content model
 
 ## 11.42

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 11.43 
+
+* Adds an implicit designType field to Content model
+
 ## 11.42
 * Update content-api-models to 11.42 (timeline atom flexible date formats)
 

--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,9 @@ libraryDependencies ++= Seq(
   "com.squareup.okhttp3" % "okhttp" % "3.9.0",
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "com.google.guava" % "guava" % "19.0" % "test"
+  "com.google.guava" % "guava" % "19.0" % "test",
+  "org.mockito" % "mockito-all" % "1.9.0" % "test"
+
 )
 
 initialCommands in console := """

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "11.42"
+val CapiModelsVersion = "11.43"
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % CapiModelsVersion,

--- a/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -1,7 +1,6 @@
 package com.gu.contentapi.client.utils
 
 import com.gu.contentapi.client.model.v1._
-
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
@@ -15,4 +14,36 @@ object CapiModelEnrichment {
     def toCapiDateTime: CapiDateTime = CapiDateTime.apply(dt.toInstant.toEpochMilli, DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dt))
   }
 
+  implicit class RichContent(val content: Content) extends AnyVal {
+
+    def designType: DesignType = {
+
+      val defaultDesignType = Article
+
+      type ContentFilter = Content => Boolean
+
+      val isImmersive: ContentFilter = c => c.fields.flatMap(_.displayHint).map(_.equals("immersive")).getOrElse(false)
+
+      def tagExistsWithId(tagId: String): ContentFilter = c => c.tags.exists(tag => tag.id == tagId)
+
+      val isMedia: ContentFilter = c => tagExistsWithId("type/audio")(c) || tagExistsWithId("type/video")(c) || tagExistsWithId("type/gallery")(c)
+
+      val isReview: ContentFilter = c => tagExistsWithId("tone/reviews")(c) || tagExistsWithId("tone/livereview")(c) || tagExistsWithId("tone/albumreview")(c)
+
+      def isComment: ContentFilter = c => tagExistsWithId("tone/comment")(c) || tagExistsWithId("tone/letters")(c)
+
+      val predicates: List[(ContentFilter, DesignType)] = List (
+          isImmersive -> Immersive,
+          isMedia -> Media,
+          isReview -> Review,
+          tagExistsWithId("tone/analysis") -> Analysis,
+          isComment -> Comment,
+          tagExistsWithId("tone/features") -> Feature,
+          tagExistsWithId("tone/minutebyminute") -> Live
+      )
+
+      val result = predicates.collectFirst { case (predicate, design) if predicate(content) => design }
+      result.getOrElse(defaultDesignType)
+    }
+  }
 }

--- a/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+++ b/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
@@ -1,0 +1,20 @@
+package com.gu.contentapi.client.utils
+
+sealed trait DesignType
+
+case object Article extends DesignType
+
+case object Immersive extends DesignType
+
+case object Media extends DesignType
+
+case object Review extends DesignType
+
+case object Analysis extends DesignType
+
+case object Comment extends DesignType
+
+case object Feature extends DesignType
+
+case object Live extends DesignType
+

--- a/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -1,0 +1,161 @@
+package com.gu.contentapi.client.model.utils
+
+import com.gu.contentapi.client.model.v1.{Content, ContentFields, Tag}
+import com.gu.contentapi.client.utils.CapiModelEnrichment._
+import com.gu.contentapi.client.utils._
+import org.mockito.Mockito._
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.mockito.MockitoSugar
+
+
+class CapiModelEnrichmentTest extends FlatSpec with MockitoSugar with Matchers {
+
+  it should  "have a designType of 'Media' when tag type/video is present" in {
+
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("type/video")
+    when(content.fields) thenReturn(None)
+    when(content.tags) thenReturn(List(tag))
+
+    content.designType shouldEqual(Media)
+  }
+
+  it should  "have a designType of 'Media' when tag type/audio is present" in {
+
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("type/audio")
+    when(content.fields) thenReturn(None)
+    when(content.tags) thenReturn(List(tag))
+
+    content.designType shouldEqual(Media)
+  }
+
+  it should  "have a designType of 'Media' when tag type/gallery is present" in {
+
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("type/gallery")
+    when(content.fields) thenReturn(None)
+    when(content.tags) thenReturn(List(tag))
+
+    content.designType shouldEqual(Media)
+  }
+
+  it should  "have a designType of 'Review' when tag tone/reviews is present" in {
+
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/reviews")
+    when(content.fields) thenReturn(None)
+    when(content.tags) thenReturn(List(tag))
+
+    content.designType shouldEqual(Review)
+  }
+
+  it should  "have a designType of 'Review' when tag tone/livereview is present" in {
+
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/livereview")
+    when(content.fields) thenReturn(None)
+    when(content.tags) thenReturn(List(tag))
+
+    content.designType shouldEqual(Review)
+  }
+
+  it should  "have a designType of 'Review' when tag tone/albumreview is present" in {
+
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/albumreview")
+    when(content.fields) thenReturn(None)
+    when(content.tags) thenReturn(List(tag))
+
+    content.designType shouldEqual(Review)
+  }
+
+  it should  "have a designType of 'Comment' when tag tone/comment is present" in {
+
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/comment")
+    when(content.fields) thenReturn(None)
+    when(content.tags) thenReturn(List(tag))
+
+    content.designType shouldEqual(Comment)
+  }
+
+  it should  "have a designType of 'Live' when tag tone/minutebyminute is present" in {
+
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/minutebyminute")
+    when(content.fields) thenReturn(None)
+    when(content.tags) thenReturn(List(tag))
+
+    content.designType shouldEqual(Live)
+  }
+
+  it should  "have a designType of 'Feature' when tag tone/features is present" in {
+
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/features")
+    when(content.fields) thenReturn(None)
+    when(content.tags) thenReturn(List(tag))
+
+    content.designType shouldEqual(Feature)
+  }
+
+
+  it should  "have a designType of 'Analysis' when tag tone/analysis is present" in {
+
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/analysis")
+    when(content.fields) thenReturn(None)
+    when(content.tags) thenReturn(List(tag))
+
+    content.designType shouldEqual(Analysis)
+  }
+
+  it should "have a designType of 'Immersive' when the displayHint field is set to 'immersive'" in {
+    val content = mock[Content]
+    val fields = mock[ContentFields]
+
+    when(content.fields) thenReturn (Some(fields))
+    when(fields.displayHint) thenReturn(Some("immersive"))
+
+    content.designType shouldEqual(Immersive)
+  }
+
+  //test one example of filters being applied in priority order
+  it should "return a designType of 'Media' over a designType of 'Comment' where tags for botth are present'" in {
+    val content = mock[Content]
+    val commentTag = mock[Tag]
+    val videoTag = mock[Tag]
+
+    when(commentTag.id) thenReturn("tone/comment")
+    when(videoTag.id) thenReturn("type/video")
+    when(content.fields) thenReturn (None)
+    when(content.tags) thenReturn( List(commentTag, videoTag))
+
+    content.designType shouldEqual(Media)
+
+  }
+
+
+
+}


### PR DESCRIPTION
@mchv This is the change you were discussing with @alexduf . It ports the logic in a (reverted) MAPI PR: https://github.com/guardian/mobile-apps-api/pull/1021 * to implement the Garnett contentType logic on the api-client. 

*This is reverted because 'contentType' clashes with a attribute on a client-side object which caused the app to crash. We'll reimplement using a new attribute name. 

Why does updating the changelog break the build?

@alexduf 

