### PR TITLE
add support for more design types

### DIFF
--- a/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -22,7 +22,7 @@ object CapiModelEnrichment {
 
       type ContentFilter = Content => Boolean
 
-      val isImmersive: ContentFilter = c => c.fields.flatMap(_.displayHint).map(_.equals("immersive")).getOrElse(false)
+      val isImmersive: ContentFilter = c => c.fields.flatMap(_.displayHint).contains("immersive")
 
       def tagExistsWithId(tagId: String): ContentFilter = c => c.tags.exists(tag => tag.id == tagId)
 
@@ -33,13 +33,18 @@ object CapiModelEnrichment {
       def isComment: ContentFilter = c => tagExistsWithId("tone/comment")(c) || tagExistsWithId("tone/letters")(c)
 
       val predicates: List[(ContentFilter, DesignType)] = List (
-          isImmersive -> Immersive,
-          isMedia -> Media,
-          isReview -> Review,
-          tagExistsWithId("tone/analysis") -> Analysis,
-          isComment -> Comment,
-          tagExistsWithId("tone/features") -> Feature,
-          tagExistsWithId("tone/minutebyminute") -> Live
+        tagExistsWithId("tone/quizzes") -> Quiz,
+        tagExistsWithId("tone/editorials") -> GuardianView,
+        tagExistsWithId("tone/interview") -> Interview,
+        tagExistsWithId("tone/matchreports") -> MatchReport,
+        tagExistsWithId("tone/recipe") -> Recipe,
+        isImmersive -> Immersive,
+        isMedia -> Media,
+        isReview -> Review,
+        tagExistsWithId("tone/analysis") -> Analysis,
+        isComment -> Comment,
+        tagExistsWithId("tone/features") -> Feature,
+        tagExistsWithId("tone/minutebyminute") -> Live
       )
 
       val result = predicates.collectFirst { case (predicate, design) if predicate(content) => design }

--- a/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+++ b/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
@@ -15,5 +15,6 @@ case object Recipe extends DesignType
 case object MatchReport extends DesignType
 case object Interview extends DesignType
 case object GuardianView extends DesignType
+case object GuardianLabs extends DesignType
 case object Quiz extends DesignType
 

--- a/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+++ b/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
@@ -3,18 +3,17 @@ package com.gu.contentapi.client.utils
 sealed trait DesignType
 
 case object Article extends DesignType
-
 case object Immersive extends DesignType
-
 case object Media extends DesignType
-
 case object Review extends DesignType
-
 case object Analysis extends DesignType
-
 case object Comment extends DesignType
-
 case object Feature extends DesignType
-
 case object Live extends DesignType
+case object SpecialReport extends DesignType
+case object Recipe extends DesignType
+case object MatchReport extends DesignType
+case object Interview extends DesignType
+case object GuardianView extends DesignType
+case object Quiz extends DesignType
 

--- a/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -134,15 +134,73 @@ class CapiModelEnrichmentTest extends FlatSpec with MockitoSugar with Matchers {
   it should "have a designType of 'Immersive' when the displayHint field is set to 'immersive'" in {
     val content = mock[Content]
     val fields = mock[ContentFields]
+    val tag = mock[Tag]
 
+    when(tag.id) thenReturn ("tone/analysis")
+    when(content.tags) thenReturn(List(tag))
     when(content.fields) thenReturn (Some(fields))
     when(fields.displayHint) thenReturn(Some("immersive"))
 
     content.designType shouldEqual(Immersive)
   }
 
+  it should "have a designType of 'Quiz' when tag tone/quizzes is present" in {
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/quizzes")
+    when(content.tags) thenReturn(List(tag))
+    when(content.fields) thenReturn(None)
+
+    content.designType shouldEqual(Quiz)
+  }
+
+  it should "have a designType of 'GuardianView' when tag tone/editorials is present" in {
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/editorials")
+    when(content.tags) thenReturn(List(tag))
+    when(content.fields) thenReturn(None)
+
+    content.designType shouldEqual(GuardianView)
+  }
+
+  it should "have a designType of 'Interview' when tag tone/interview is present" in {
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/interview")
+    when(content.tags) thenReturn(List(tag))
+    when(content.fields) thenReturn(None)
+
+    content.designType shouldEqual(Interview)
+  }
+
+  it should "have a designType of 'MatchReport' when tag tone/matchreports is present" in {
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/matchreports")
+    when(content.tags) thenReturn(List(tag))
+    when(content.fields) thenReturn(None)
+
+    content.designType shouldEqual(MatchReport)
+  }
+
+  it should "have a designType of 'Recipe' when tag tone/recipe is present" in {
+    val content = mock[Content]
+    val tag = mock[Tag]
+
+    when(tag.id) thenReturn ("tone/recipe")
+    when(content.tags) thenReturn(List(tag))
+    when(content.fields) thenReturn(None)
+
+    content.designType shouldEqual(Recipe)
+  }
+
   //test one example of filters being applied in priority order
-  it should "return a designType of 'Media' over a designType of 'Comment' where tags for botth are present'" in {
+  it should "return a designType of 'Media' over a designType of 'Comment' where tags for both are present'" in {
     val content = mock[Content]
     val commentTag = mock[Tag]
     val videoTag = mock[Tag]


### PR DESCRIPTION
This adds support for as many designTypes as it is possible.
Two are missing: special reports and guardian labs.

It's by constraint as they both rely on external data (respectively Fronts and Commercial) and therefore need to be treated as exceptions both in MAPI and Frontend's code.

Any question please contact me :)

cc @NathanielBennett @GHaberis 