### PR TITLE
Fix encoding

### DIFF
--- a/aws/build.sbt
+++ b/aws/build.sbt
@@ -52,5 +52,6 @@ releaseProcess := Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-core" % "1.11.259"
+  "com.amazonaws" % "aws-java-sdk-core" % "1.11.259",
+  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )

--- a/aws/readme.md
+++ b/aws/readme.md
@@ -1,0 +1,19 @@
+### content-api-client-aws
+A library for helping with requests to an IAM-authorised AWS api-gateway.
+
+Creates the necessary authorisation headers based on a request.
+E.g.
+```
+import com.gu.contentapi.client.{IAMSigner, IAMEncoder}
+
+val signer = new IAMSigner(credentialsProvider, awsRegion))
+
+//Query params must be encoded correctly
+val queryString = IAMEncoder.encodeParams("testparam=with spaces")
+
+val uri = URI.create(s"$endpoint/$path?$queryString")
+
+val headers: Map[String,String] = signer.addIAMHeaders(Map.empty[String,String], uri)
+
+//...create a request with uri and headers
+```

--- a/aws/src/main/scala/com/gu/contentapi/client/IAMEncoder.scala
+++ b/aws/src/main/scala/com/gu/contentapi/client/IAMEncoder.scala
@@ -1,0 +1,37 @@
+package com.gu.contentapi.client
+
+import java.net.URLEncoder
+
+/**
+  * Requests to an IAM-authorised api-gateway must conform to AWS sig4v specification
+  */
+object IAMEncoder {
+
+  private def encode(v: String) = URLEncoder.encode(v, "UTF-8").replace("+", "%20")
+
+  /**
+    * URL query params must be encoded correctly for the api-gateway authorisation to work.
+    * Note - the URL passed to `IAMSigner.addIAMHeaders` must match the URL of the request.
+    *
+    * @param params Map of query params
+    * @return Query params string
+    */
+  def encodeParams(params: Map[String, Seq[String]]): String = {
+    params.map { case (key, value) =>
+      s"${encode(key)}=${encode(value.mkString(","))}"
+    }.mkString("&")
+  }
+
+  /**
+    * URL query params must be encoded correctly for the api-gateway authorisation to work.
+    * Note - the URL passed to `IAMSigner.addIAMHeaders` must match the URL of the request.
+    *
+    * @param params Query params string
+    * @return Query params string
+    */
+  def encodeParams(params: String): String =
+    params.split("&")
+      .map(_.split("="))
+      .collect { case Array(k, v) => s"${encode(k)}=${encode(v)}" }
+      .mkString("&")
+}

--- a/aws/src/main/scala/com/gu/contentapi/client/IAMSigner.scala
+++ b/aws/src/main/scala/com/gu/contentapi/client/IAMSigner.scala
@@ -1,5 +1,7 @@
 package com.gu.contentapi.client
 
+import java.net.URI
+
 import com.amazonaws.DefaultRequest
 import com.amazonaws.auth.{AWS4Signer, AWSCredentialsProvider}
 import com.amazonaws.http.HttpMethodName
@@ -24,14 +26,13 @@ class IAMSigner(credentialsProvider: AWSCredentialsProvider, awsRegion: String) 
     * Returns the given set of headers, updated to include AWS sig4v signed headers based on the request and the credentials
     *
     * @param headers  Current set of request headers
-    * @param url      Request URL, including params
+    * @param uri      Request URI, including params
     * @return         Updated set of headers, including the authorisation headers
     */
-  def addIAMHeaders(headers: Map[String, String], url: String): Map[String, String] = {
+  def addIAMHeaders(headers: Map[String, String], uri: URI): Map[String, String] = {
     val requestToSign = {
       val req = new DefaultRequest(serviceName)
 
-      val uri = new java.net.URI(url)
       req.setHeaders(headers.asJava)
       req.setEndpoint(new java.net.URI(s"${uri.getScheme}://${uri.getHost}"))
       req.setHttpMethod(HttpMethodName.GET)

--- a/aws/src/test/scala/com/gu/contentapi/client/IAMEncoderSpec.scala
+++ b/aws/src/test/scala/com/gu/contentapi/client/IAMEncoderSpec.scala
@@ -1,0 +1,16 @@
+package com.gu.contentapi.client
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class IAMEncoderSpec extends FlatSpec with Matchers {
+  it should "encode a map of query params" in {
+    IAMEncoder.encodeParams("a=b c&1=2,3") should be("a=b%20c&1=2%2C3")
+  }
+
+  it should "encode a query params string" in {
+    IAMEncoder.encodeParams(Map(
+      "a" -> Seq("b c"),
+      "1" -> Seq("2","3")
+    )) should be("a=b%20c&1=2%2C3")
+  }
+}


### PR DESCRIPTION
The java `URLEncoder` encodes spaces as `+`, but api-gateway will only accept `%20` for authorisation. This caused requests from one of our apps to fail.
This PR introduces `IAMEncoder` for ensuring the query params are encoded correctly.
I've also added an alternative `addIAMHeaders` method for a `URI` parameter, in addition to `string`.