### PR TITLE
Encode query param spaces as %20

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.51
+* Encode query param spaces as %20
+
 ## 11.50
 * Use cats 1.0 (via content-api-models 11.50)
 

--- a/client/src/main/scala/com.gu.contentapi.client/utils/QueryStringParams.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/QueryStringParams.scala
@@ -5,7 +5,11 @@ import java.net.URLEncoder
 object QueryStringParams {
   def apply(parameters: Iterable[(String, String)]) = {
     def encodeParameter(p: String): String = p match {
-      case other => URLEncoder.encode(other, "UTF-8")
+      /**
+        * api-gateway IAM authorisation requires that spaces are encoded as `%20`, not `+`.
+        * https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+        */
+      case other => URLEncoder.encode(other, "UTF-8").replace("+", "%20")
     }
 
     if (parameters.isEmpty) {


### PR DESCRIPTION
apps that do not use the scala-client will still need to do this themselves