### PR TITLE
Cats 1

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.50
+* Use cats 1.0 (via content-api-models 11.50)
+
 ## 11.49
 * Update designType algorithm to prioritise immersive over everything else
 

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -80,7 +80,7 @@ buildInfoKeys := Seq[BuildInfoKey](version)
 buildInfoPackage := "com.gu.contentapi.buildinfo"
 buildInfoObject := "CapiBuildInfo"
 
-val CapiModelsVersion = "11.48"
+val CapiModelsVersion = "11.50"
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % CapiModelsVersion,

--- a/client/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -12,7 +12,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class GuardianContentClientTest extends FlatSpec with Matchers with ScalaFutures with OptionValues with BeforeAndAfterAll with Inside {
 
-  private val api = new GuardianContentClient("test")
+  private val apiKey = System.getenv("API_KEY")
+  private val api = new GuardianContentClient(apiKey)
   private val TestItemPath = "commentisfree/2012/aug/01/cyclists-like-pedestrians-must-get-angry"
 
   override def afterAll() {


### PR DESCRIPTION
via the new content-api-models
(and fix the atom tests)