### PR TITLE
Fix conversion from milliseconds to seconds

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 11.52
+* Fix regression of read and connect timeouts being 1000 and 2000 instead of 1 and 2 seconds
+
 ## 11.51
 * Encode query param spaces as %20
 

--- a/client/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -19,8 +19,8 @@ trait ContentApiClientLogic {
   protected val userAgent = "content-api-scala-client/"+CapiBuildInfo.version
 
   protected lazy val http = new OkHttpClient.Builder()
-    .connectTimeout(1000, TimeUnit.SECONDS)
-    .readTimeout(2000, TimeUnit.SECONDS)
+    .connectTimeout(1, TimeUnit.SECONDS)
+    .readTimeout(2, TimeUnit.SECONDS)
     .followRedirects(true)
     .connectionPool(new ConnectionPool(10, 60, TimeUnit.SECONDS))
     .build()


### PR DESCRIPTION
When we migrated code [from `dispatch` to `okhttp`](https://github.com/guardian/content-api-scala-client/pull/230/files) connect and read timeouts were increased by `1000`! Frontend has [implemented a workaround](https://github.com/guardian/frontend/pull/19027)



@annebyrne nice little 🐛 we unfortunately did not catch at review 