### PR TITLE
Fix content encoding

### DIFF
--- a/aws/src/main/scala/com/gu/contentapi/client/IAMSigner.scala
+++ b/aws/src/main/scala/com/gu/contentapi/client/IAMSigner.scala
@@ -50,6 +50,6 @@ class IAMSigner(credentialsProvider: AWSCredentialsProvider, awsRegion: String) 
     }
 
     signer.sign(requestToSign, credentialsProvider.getCredentials)
-    requestToSign.getHeaders.asScala.toMap + ("Accept-Encoding" -> "identity")
+    requestToSign.getHeaders.asScala.toMap
   }
 }


### PR DESCRIPTION
`identity` means no encoding!
compression needs to be enabled manually in api-gateway (and of course it's not possible to do with cloudformation yet) so I've done this