### PR TITLE
Make `SearchQuery` customisable

### DIFF
--- a/aws/build.sbt
+++ b/aws/build.sbt
@@ -25,8 +25,8 @@ publishMavenStyle := true
 publishArtifact in Test := false
 pomIncludeRepository := { _ => false }
 description := "AWS helper functionality for using Guardian's Content API scala client"
-scalaVersion := "2.12.3"
-crossScalaVersions := Seq("2.11.11", scalaVersion.value)
+scalaVersion := "2.12.4"
+crossScalaVersions := Seq("2.11.12", scalaVersion.value)
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 organization := "com.gu"
 licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))

--- a/aws/build.sbt
+++ b/aws/build.sbt
@@ -52,6 +52,6 @@ releaseProcess := Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-core" % "1.11.259",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+  "com.amazonaws" % "aws-java-sdk-core" % "1.11.280",
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 )

--- a/aws/build.sbt
+++ b/aws/build.sbt
@@ -34,7 +34,7 @@ scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/content-api-scala-client"),
   "scm:git:git@github.com:guardian/content-api-scala-client.git"
 ))
-javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 releaseProcess := Seq(
   checkSnapshotDependencies,

--- a/aws/project/build.properties
+++ b/aws/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.1

--- a/aws/project/plugins.sbt
+++ b/aws/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 11.53
+* Extract a `SearchQueryBase` as the parent of `SearchQuery`.
+  This helps with customising search queries (e.g. using a different path or more parameters).
+* Upgrade patch versions for Scala (2.12.4 and 2.11.12) and okhttp (3.9.1).
+* Set the target JVM to 1.8.
+
 ## 11.52
 * Fix regression of read and connect timeouts being 1000 and 2000 instead of 1 and 2 seconds
 

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -84,12 +84,11 @@ val CapiModelsVersion = "11.50"
 
 libraryDependencies ++= Seq(
   "com.gu" %% "content-api-models-scala" % CapiModelsVersion,
-  "com.squareup.okhttp3" % "okhttp" % "3.9.0",
+  "com.squareup.okhttp3" % "okhttp" % "3.9.1",
   "org.slf4j" % "slf4j-api" % "1.7.25",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
   "com.google.guava" % "guava" % "19.0" % "test",
-  "org.mockito" % "mockito-all" % "1.9.0" % "test"
-
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test" exclude("org.mockito", "mockito-core"),
+  "org.mockito" % "mockito-all" % "1.10.19" % "test"
 )
 
 initialCommands in console := """

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -51,8 +51,8 @@ publishMavenStyle := true
 publishArtifact in Test := false
 pomIncludeRepository := { _ => false }
 description := "Scala client for the Guardian's Content API"
-scalaVersion := "2.12.3"
-crossScalaVersions := Seq("2.11.11", scalaVersion.value)
+scalaVersion := "2.12.4"
+crossScalaVersions := Seq("2.11.12", scalaVersion.value)
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 organization := "com.gu"
 licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -60,7 +60,7 @@ scmInfo := Some(ScmInfo(
   url("https://github.com/guardian/content-api-scala-client"),
   "scm:git:git@github.com:guardian/content-api-scala-client.git"
 ))
-javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 scalacOptions ++= Seq("-deprecation", "-unchecked")
 releaseProcess := Seq(
   checkSnapshotDependencies,

--- a/client/project/build.properties
+++ b/client/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.1

--- a/client/project/plugins.sbt
+++ b/client/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.1")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -13,6 +13,19 @@ sealed trait ContentApiQuery {
   }
 }
 
+trait SearchQueryBase[Self <: SearchQueryBase[Self]]
+  extends ContentApiQuery
+     with ShowParameters[Self]
+     with ShowReferencesParameters[Self]
+     with OrderByParameter[Self]
+     with UseDateParameter[Self]
+     with PaginationParameters[Self]
+     with FilterParameters[Self]
+     with FilterExtendedParameters[Self]
+     with FilterSearchParameters[Self] {
+  this: Self =>
+}
+
 case class ItemQuery(id: String, parameterHolder: Map[String, Parameter] = Map.empty)
   extends ContentApiQuery
   with EditionParameters[ItemQuery]
@@ -35,17 +48,9 @@ case class ItemQuery(id: String, parameterHolder: Map[String, Parameter] = Map.e
 }
 
 case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-  extends ContentApiQuery
-  with ShowParameters[SearchQuery]
-  with ShowReferencesParameters[SearchQuery]
-  with OrderByParameter[SearchQuery]
-  with UseDateParameter[SearchQuery]
-  with PaginationParameters[SearchQuery]
-  with FilterParameters[SearchQuery]
-  with FilterExtendedParameters[SearchQuery]
-  with FilterSearchParameters[SearchQuery] {
+  extends SearchQueryBase[SearchQuery] {
 
-  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+  def withParameters(parameterMap: Map[String, Parameter]): SearchQuery = copy(parameterMap)
 
   override def pathSegment: String = "search"
 }

--- a/client/version.sbt
+++ b/client/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "11.52"
+version in ThisBuild := "11.52-SNAPSHOT"

--- a/client/version.sbt
+++ b/client/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "11.52-SNAPSHOT"
+version in ThisBuild := "11.52"


### PR DESCRIPTION
This PR extracts a reusable trait out of `SearchQuery`.

This enables us to create other kinds of queries that expect a `SearchResponse` as a result. We can add more parameters and change the path.

Importantly, the trait is _not_ sealed so other projects can create custom implementations.

On the side, upgrade dependencies as well as sbt and its plugins. Additionally, change the target JVM to 1.8 to make use of compiler optimisations.