### PR TITLE
Extensible default client

### DIFF
--- a/client-default/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
+++ b/client-default/src/main/scala/com.gu.contentapi.client/GuardianContentClient.scala
@@ -8,12 +8,13 @@ import scala.concurrent.{ExecutionContext, Future, Promise}
 
 class GuardianContentClient(val apiKey: String) extends ContentApiClient {
 
-  private val http = new OkHttpClient.Builder()
+  protected def httpClientBuilder = new OkHttpClient.Builder()
     .connectTimeout(1, TimeUnit.SECONDS)
     .readTimeout(2, TimeUnit.SECONDS)
     .followRedirects(true)
     .connectionPool(new ConnectionPool(10, 60, TimeUnit.SECONDS))
-    .build()
+
+  protected val http = httpClientBuilder.build
 
   def get(url: String, headers: Map[String, String])(implicit context: ExecutionContext): Future[HttpResponse] = {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val scalaVersions = Seq("2.11.12", "2.12.5")
+  val scalaVersions = Seq("2.11.12", "2.12.6")
 
   val CapiModelsVersion = "12.0"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.1.4


### PR DESCRIPTION
Enable the `OkHttpClient` to be customised in classes that extend `GuardianContentClient`.