### PR TITLE
Remove the dependency on SLF4J

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,6 @@ object Dependencies {
 
   val defaultClientDeps = Seq(
     "com.squareup.okhttp3" % "okhttp" % "3.9.1",
-    "org.slf4j" % "slf4j-api" % "1.7.25"
   )
 
   val awsDeps = Seq(


### PR DESCRIPTION
It's currently unused, adding unnecessary weight to libraries that use this.