### PR TITLE
Remove PgpKeys.useGpg setting 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,7 @@ lazy val root = (project in file("."))
     skip in publish    := true,
     releaseVersionFile := baseDirectory.value / "version.sbt",
     sources in Compile := Seq.empty,
-    sources in Test    := Seq.empty,
-    Global / PgpKeys.useGpg := true
+    sources in Test    := Seq.empty
   )
 
 lazy val client = (project in file("client"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.4
+sbt.version=1.1.5


### PR DESCRIPTION
This was causing release to fail on my machine with the error `gpg: signing failed: No secret key`.
