### PR TITLE
CAPI Models: bump content-api-model version

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 12.7
+* bump content-api-models to 12.7 (adds `googlePodcastsUrl` and `spotifyUrl` to the Tag Podcast model)
+
 ## 12.6
 * [#272](https://github.com/guardian/content-api-scala-client/pull/272) Adds ids parameter to RemovedContentQuery
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.6")
 
-  val CapiModelsVersion = "12.5"
+  val CapiModelsVersion = "12.7"
 
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
This increments the content-api-models to the latest version.

Related: 
Version bumped in Concierge:  https://github.com/guardian/content-api/pull/2172

Changes in Content Api Models: https://github.com/guardian/content-api-models/pull/147