### PR TITLE
added a dependancy on slf4j logging api to fix error handling

### DIFF
--- a/client/src/test/scala/com.gu.contentapi.client/model/ContentApiErrorTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/ContentApiErrorTest.scala
@@ -1,0 +1,9 @@
+package com.gu.contentapi.client.model
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class ContentApiErrorTest extends FlatSpec with Matchers  {
+  "ContentApiError" should "Handle error responses properly" in {
+    ContentApiError(HttpResponse(Array(), 500, "error")) should be (ContentApiError(500, "error"))
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,12 +8,12 @@ object Dependencies {
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,
     "org.scalatest" %% "scalatest" % "3.0.5" % "test" exclude("org.mockito", "mockito-core"),
+    "org.slf4j" % "slf4j-api" % "1.7.25",
     "org.mockito" % "mockito-all" % "1.10.19" % "test"
   )
 
   val defaultClientDeps = Seq(
-    "com.squareup.okhttp3" % "okhttp" % "3.9.1",
-    "org.slf4j" % "slf4j-api" % "1.7.25"
+    "com.squareup.okhttp3" % "okhttp" % "3.9.1"
   )
 
   val awsDeps = Seq(


### PR DESCRIPTION
I found an issue where a Fatal exception was being thrown on line 11 of contentApiError.

This was due to a missing slf4j api dependancy. Instantiating the ThriftDeserializer class caused a fatal java.lang.NoClassDefFoundError exception.

The impact of this was that failing requests would return a future that never completed.

I added a couple failing tests, added the import and the tests passed.