### PR TITLE
Add support for atom usage queries

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/ContentApiClient.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/ContentApiClient.scala
@@ -5,6 +5,7 @@ import com.gu.contentapi.client.model._
 import com.gu.contentapi.client.model.v1._
 import com.gu.contentapi.client.thrift.ThriftDeserializer
 import com.gu.contentapi.client.utils.QueryStringParams
+import com.gu.contentatom.thrift.AtomType
 import scala.concurrent.{ExecutionContext, Future}
 
 trait ContentApiClient {
@@ -149,6 +150,7 @@ trait ContentApiQueries {
   val editions = EditionsQuery()
   val removedContent = RemovedContentQuery()
   val atoms = AtomsQuery()
+  def atomUsage(atomType: AtomType, atomId: String) = AtomUsageQuery(atomType, atomId)
   val recipes = RecipesQuery()
   val reviews = ReviewsQuery()
   val gameReviews = GameReviewsQuery()

--- a/client/src/main/scala/com.gu.contentapi.client/model/Decoder.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Decoder.scala
@@ -46,5 +46,5 @@ private[client] object Decoder {
   implicit val storiesQuery = apply[StoriesQuery, StoriesResponse](StoriesResponse)
   implicit def searchQueryBase[T <: SearchQueryBase[T]] = apply[T, SearchResponse](SearchResponse)
   implicit def nextQuery[Q <: PaginatedApiQuery[Q]](implicit d: Decoder[Q]) = apply[NextQuery[Q], d.Response](d.codec)
-
+  implicit def atomsUsageQuery = apply[AtomUsageQuery, AtomUsageResponse](AtomUsageResponse)
 }

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -2,6 +2,7 @@ package com.gu.contentapi.client.model
 
 import com.gu.contentapi.client.utils.QueryStringParams
 import com.gu.contentapi.client.{Parameter, Parameters}
+import com.gu.contentatom.thrift.AtomType
 
 sealed trait ContentApiQuery {
   def parameters: Map[String, String]
@@ -130,6 +131,15 @@ case class AtomsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
   def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
 
   override def pathSegment: String = "atoms"
+}
+
+case class AtomUsageQuery(atomType: AtomType, atomId: String, parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ContentApiQuery
+  with PaginationParameters[AtomUsageQuery] {
+  
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterHolder = parameterMap)
+
+  override def pathSegment: String = s"atom/$atomType/$atomId/usage"
 }
 
 case class RecipesQuery(parameterHolder: Map[String, Parameter] = Map.empty)


### PR DESCRIPTION
One can get the list of content IDs where a specific atom is embedded by querying the following endpoint:
```
  /atom/<atomType>/<atomId>/usage
```
For example, https://content.guardianapis.com/atom/media/2db8bf1c-7151-4cdd-a61c-be444052aa32/usage yields

![screen shot 2018-09-14 at 08 45 27](https://user-images.githubusercontent.com/629976/45536824-7821fb00-b7fa-11e8-8725-f87d018d0d13.png)

This PR adds support for these queries in the client. As far as I know, only pagination parameters are useful here.