### PR TITLE
Add support for "use-date" parameter in atom queries

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -125,7 +125,7 @@ case class AtomsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
   extends ContentApiQuery
   with AtomsParameters[AtomsQuery]
   with PaginationParameters[AtomsQuery]
-  with UseDateParameters[AtomsQuery]
+  with UseDateParameter[AtomsQuery]
   with OrderByParameter[AtomsQuery]
   with FilterSearchParameters[AtomsQuery] {
 

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -125,6 +125,7 @@ case class AtomsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
   extends ContentApiQuery
   with AtomsParameters[AtomsQuery]
   with PaginationParameters[AtomsQuery]
+  with UseDateParameters[AtomsQuery]
   with OrderByParameter[AtomsQuery]
   with FilterSearchParameters[AtomsQuery] {
 


### PR DESCRIPTION
This is [supported in CAPI](https://github.com/guardian/content-api/blob/master/concierge/src/main/scala/com.gu.contentapi.concierge/parameters/AtomParameters.scala#L40-L53) but currently missing in the client.