### PR TITLE
Bump models dep to v14.2

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 14.2
+
+* Version 14.1 of the models dependency was empty
+
 ## 14.0 (13.0 is skipped)
 
 * Upgrades to Scrooge 19.3, which uses libthrift 0.10

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.8")
 
-  val CapiModelsVersion = "14.1"
+  val CapiModelsVersion = "14.2"
 
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
Version 14.1 of the models dependency was empty