### PR TITLE
WIP: bump capi model for emailsignup atom support

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## XX.X //TODO: put in version number when published
+
+* Bump version of content-api-models to XX.XX (add support for the emailsignup atom) //TODO: put in version number when published
+
 ## 14.2
 
 * Version 14.1 of the models dependency was empty

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.8")
 
-  val CapiModelsVersion = "14.2"
+  val CapiModelsVersion = "14.2" //TODO: change this to latest version of content-api-models
 
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
This is a placeholder PR for when the changes in https://github.com/guardian/content-api-models/pull/169 have been merged and content-api-models has been published.