### PR TITLE
Add advertisement feature design type

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 15.7
+
+* Add AdvertisementFeature design type
+
 ## 15.6
 
 * Require clients to implement a ContentApiBackoff retry strategy along with an implicitly declared ScheduledExecutor. See the README for more info.

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -39,6 +39,7 @@ object CapiModelEnrichment {
       val deadBlog: ContentFilter = !liveBloggingNow && tagExistsWithId("tone/minutebyminute")(_)
 
       val predicates: List[(ContentFilter, DesignType)] = List (
+        tagExistsWithId("tone/advertisement-features") -> AdvertisementFeature,
         tagExistsWithId("tone/matchreports") -> MatchReport,
         tagExistsWithId("tone/quizzes") -> Quiz,
         isImmersive -> Immersive,

--- a/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
@@ -17,4 +17,4 @@ case object Interview extends DesignType
 case object GuardianView extends DesignType
 case object GuardianLabs extends DesignType
 case object Quiz extends DesignType
-
+case object AdvertisementFeature extends DesignType


### PR DESCRIPTION
Sets design type to the new value of `AdvertisementFeature` when advertising-feature tone tag is present.

We already perform this logic in Frontend, but feels better to do it at source. See: https://github.com/guardian/frontend/blob/master/article/app/model/dotcomponents/DotcomponentsDataModel.scala#L400

@JustinPinner and @regiskuckaertz not sure exactly how to deploy a new version here and what is involved beyond the changelog addition. Can you help?!