### PR TITLE
Add Request-Attempt header to CAPI requests

### DIFF
--- a/client-default/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/client-default/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -71,11 +71,12 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ScalaFutures
     content.futureValue.id should be (TestItemPath)
   }
 
-  it should "perform a given removed content query" in {
+  it should "return a 404 in response to a removed (expired) content query" in {
     val query = ContentApiClient.removedContent.reason("expired")
-    val results = for (response <- api.getResponse(query)) yield response.results
-    val fResults = results.futureValue
-    fResults.size should be (10)
+    val errorTest = api.getResponse(query) recover { case error =>
+      error should be (ContentApiError(404, "Not Found", Some(ErrorResponse("error", "The requested resource could not be found."))))
+    }
+    errorTest.futureValue
   }
 
   it should "perform a given atoms query" in {

--- a/client-default/version.sbt
+++ b/client-default/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "14.3-SNAPSHOT"
+version in ThisBuild := "15.8-SNAPSHOT"

--- a/client-default/version.sbt
+++ b/client-default/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "15.9-SNAPSHOT"
+version in ThisBuild := "16.0-SNAPSHOT"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 16.0
 
-* Add a Retry-Count header so we can see the behaviour of the backoff code in Kibana
+* Add a `Request-Attempt` header that is set to zero for any initial request and incremented by one for each retry - so that we can see the behaviour of the backoff code in Kibana
 
 ## 15.8
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 15.9
+## 16.0
 
 * Add a Retry-Count header so we can see the behaviour of the backoff code in Kibana
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 15.8
+
+* Add a Retry-Count header so we can see the behaviour of the backoff code in Kibana
+* Update expired content test to ensure we return a 404
+
 ## 15.7
 
 * Add AdvertisementFeature design type

--- a/client/src/main/scala/com.gu.contentapi.client/ContentApiClient.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/ContentApiClient.scala
@@ -42,7 +42,7 @@ trait ContentApiClient {
 
   /** Some HTTP headers sent along each CAPI request */
   private def headers(retry: Int) =
-    Map("User-Agent" -> userAgent, "Accept" -> "application/x-thrift", "x-retry" -> s"$retry")
+    Map("User-Agent" -> userAgent, "Accept" -> "application/x-thrift", "Request-Attempt" -> s"$retry", "Accept-Language" -> "*")
 
   /** Authentication and format parameters appended to each query */
   private def parameters = Map("api-key" -> apiKey, "format" -> "thrift")

--- a/client/version.sbt
+++ b/client/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "14.3-SNAPSHOT"
+version in ThisBuild := "15.8-SNAPSHOT"

--- a/client/version.sbt
+++ b/client/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "15.9-SNAPSHOT"
+version in ThisBuild := "16.0-SNAPSHOT"

--- a/project/Metadata.scala
+++ b/project/Metadata.scala
@@ -30,6 +30,7 @@ object Metadata {
         , Developer(id="cb372", name="Chris Birchall", email="", url=url("https://github.com/cb372"))
         , Developer(id="tomrf1", name="Tom Forbes", email="", url=url("https://github.com/tomrf1"))
         , Developer(id="regiskuckaertz", name="Regis Kuckaertz", email="", url=url("https://github.com/regiskuckaertz"))
+        , Developer(id="JustinPinner", name="Justin Pinner", email="", url=url("https://github.com/JustinPinner"))
         )
 
   val awsDevs = 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "15.9-SNAPSHOT"
+version in ThisBuild := "16.0-SNAPSHOT"


### PR DESCRIPTION
When requests are made through the backoff object, we keep a counter of the number of attempts we've made for the resource.

To help us understand how the backoff implementations are working it'd be really handy to be able to see how frequently the retry code is activating, and we'd like to see that in our server logs, so we figured adding a header to every request was a reasonable way of achieving that.

While it's tempting to _not_ send a header _unless_ it's a retry attempt, sending it with a zero value for the initial request will be useful as we'll be able to know for certain that clients have started using the new library version as we expect most of the requests to have a Request-Attempt value of 0 (zero) - and the version number reported from the client has also been problematic so only when we know that we can rely on that will we remove the initial (zero value) header.

There is a corresponding PR in our concierge service to use log out the new header value for examination during periods of service instability.