### PR TITLE
Update to CAPI models 15.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,21 +234,7 @@ client.getResponse(usEditionsQuery) map { response =>
 
 ### Removed Content
 
-Filtering or searching for removed content happens at http://content.guardianapis.com/content/removed. For example:
-
-```scala
-// print the id of all removed content items
-val removedContentQuery = ContentApiLogic.removedContent
-client.getResponse(removedContentQuery) map { response =>
-  for (result <- response.results) println(result)
-}
-
-// print the id of all expired content
-val expiredContentQuery = ContentApiLogic.removedContent.reason("expired")
-client.getResponse(expiredContentQuery ) map { response =>
-  for (result <- response.results) println(result)
-}
-```
+This is removed in version 15.8
 
 ### Pagination
 The client allows you to paginate through results in the following ways:

--- a/client-default/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/client-default/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -71,13 +71,6 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ScalaFutures
     content.futureValue.id should be (TestItemPath)
   }
 
-  it should "perform a given removed content query" in {
-    val query = ContentApiClient.removedContent.reason("expired")
-    val results = for (response <- api.getResponse(query)) yield response.results
-    val fResults = results.futureValue
-    fResults.size should be (10)
-  }
-
   it should "perform a given atoms query" in {
     val query = ContentApiClient.atoms.types("explainer")
     val results = for (response <- api.getResponse(query)) yield response.results

--- a/client-default/version.sbt
+++ b/client-default/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "14.3-SNAPSHOT"
+version in ThisBuild := "15.8-SNAPSHOT"

--- a/client-default/version.sbt
+++ b/client-default/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "15.8-SNAPSHOT"
+version in ThisBuild := "15.8"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 15.8
+
+* Bump CAPI models to 15.6 (removed content no longer supported)
+
 ## 15.7
 
 * Add AdvertisementFeature design type

--- a/client/src/main/scala/com.gu.contentapi.client/ContentApiClient.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/ContentApiClient.scala
@@ -154,7 +154,6 @@ trait ContentApiQueries {
   val tags = TagsQuery()
   val sections = SectionsQuery()
   val editions = EditionsQuery()
-  val removedContent = RemovedContentQuery()
   val atoms = AtomsQuery()
   def atomUsage(atomType: AtomType, atomId: String) = AtomUsageQuery(atomType, atomId)
   val recipes = RecipesQuery()

--- a/client/src/main/scala/com.gu.contentapi.client/model/Decoder.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Decoder.scala
@@ -35,7 +35,6 @@ private[client] object Decoder {
   implicit val tagsQuery = apply[TagsQuery, TagsResponse](TagsResponse)
   implicit val sectionsQuery = apply[SectionsQuery, SectionsResponse](SectionsResponse)
   implicit val editionsQuery = apply[EditionsQuery, EditionsResponse](EditionsResponse)
-  implicit val removedContentQuery = apply[RemovedContentQuery, RemovedContentResponse](RemovedContentResponse)
   implicit val videoStatsQuery = apply[VideoStatsQuery, VideoStatsResponse](VideoStatsResponse)
   implicit val atomsQuery = atomsDecoder[AtomsQuery]
   implicit val recipesQuery = atomsDecoder[RecipesQuery]

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -63,20 +63,6 @@ case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty)
   override def pathSegment: String = "search"
 }
 
-case class RemovedContentQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-  extends ContentApiQuery
-  with RemovedReasonParameters[RemovedContentQuery]
-  with PaginationParameters[RemovedContentQuery]
-  with OrderByParameter[RemovedContentQuery]
-  with UseDateParameter[RemovedContentQuery]{
-
-  def ids = StringParameter("ids")
-
-  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
-
-  def pathSegment: String = "content/removed"
-}
-
 case class TagsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
   extends ContentApiQuery
   with ShowReferencesParameters[TagsQuery]
@@ -278,11 +264,6 @@ trait FilterSectionParameters[Owner <: Parameters[Owner]] extends Parameters[Own
 
 trait FilterSearchParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
   def q = StringParameter("q")
-}
-
-// Supports values gone, expired and takendown.
-trait RemovedReasonParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
-  def reason = StringParameter("reason")
 }
 
 trait AtomsParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>

--- a/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
@@ -25,7 +25,4 @@ class ContentApiQueryTest extends FlatSpec with Matchers  {
     TagsQuery().tagType("contributor").getUrl("") shouldEqual "/tags?type=contributor"
   }
 
-  "RemovedContentQuery" should "be amazing" in {
-    RemovedContentQuery().reason("gone").getUrl("") shouldEqual "/content/removed?reason=gone"
-  }
 }

--- a/client/version.sbt
+++ b/client/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "14.3-SNAPSHOT"
+version in ThisBuild := "15.8-SNAPSHOT"

--- a/client/version.sbt
+++ b/client/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "15.8-SNAPSHOT"
+version in ThisBuild := "15.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "15.5"
+  val CapiModelsVersion = "15.6"
 
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "15.8-SNAPSHOT"
+version in ThisBuild := "15.8"


### PR DESCRIPTION
With the demise of the support for removed content queries in core CAPI, we have to update the scala client accordingly.

