### PR TITLE
Bump capi models 15.9.2

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.2
+
+* Bump CAPI models to 15.9.2 (adds optional `placeholderUrl` field to interactive atoms)
+
 ## 17.1
 
 * Removed 503 from list of retryable response codes

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "15.8"
+  val CapiModelsVersion = "15.9.2"
 
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
## What does this change?
There is a new release of CAPI models that adds a new, optional `placeholderUrl` field to interactive atoms. This change picks up the latest model definitions so that the data can be included if present in the CAPI response.

Opening this PR so that we can verify prior to releasing a new update.

