### PR TITLE
Update content api model to pick up block element role fields

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "15.9.2"
+  val CapiModelsVersion = "15.9.6"
 
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
## What does this change?

Levels up to latest content api model (15.9.6) specifically to pick to role field of block element types. Makes the optional element role available to all element types.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

DCR should be able to pick to element role from an embed type element.

## Have we considered potential risks?

Field addition should be safe.
All changes since 15.9.2 are also field additions.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->