### PR TITLE
Updating content-api-model to 15.9.14

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,9 +1,17 @@
+## 17.8
+
+* Bump CAPI models to 15.9.14
+  * 15.9.13 adds `sourceDomain` to `*ElementFields`
+  * 15.9.14 removes `height` and `width` fields from `PullquoteElementFields`, `TweetElementFields`, 
+    `AudioElementFields`, `InteractiveElementFields`, `EmbedElementFields` and `InstagramElementFields`
+
 ## 17.7
 
 * Bump CAPI models to 15.9.12 
   * 15.9.10 adds `deletedContent` payload type with optional `aliasPaths` to delete events
   * 15.9.11 adds `source` fields to `PullquoteElementFields` and `EmbedElementFields`
-  * 15.9.12 adds `sourceDomain` to `*ElementFields`
+  * 15.9.12 adds `height` and `width` fields to `PullquoteElementFields`, `TweetElementFields`, `AudioElementFields`,
+    `InteractiveElementFields`, `EmbedElementFields` and `InstagramElementFields`
 
 ## 17.6
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "15.9.12"
+  val CapiModelsVersion = "15.9.14"
 
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
## What does this change?

This PR updates the content-api-model dependency to 15.9.14 which includes the following changes:
 15.9.13 adds `sourceDomain` to `*ElementFields`
 15.9.14 removes `height` and `width` fields from `PullquoteElementFields`, `TweetElementFields`, 
    `AudioElementFields`, `InteractiveElementFields`, `EmbedElementFields` and `InstagramElementFields`

For more details see:
https://github.com/guardian/content-api-models/pull/192
https://github.com/guardian/content-api-models/pull/193
