### PR TITLE
Add show alias paths parameter

### DIFF
--- a/client-default/version.sbt
+++ b/client-default/version.sbt
@@ -1,3 +1,3 @@
 // TODO: This appears to be the only version that is referenced
 //  (at least when running a +publishLocal) when publishing
-version in ThisBuild := "17.9-SNAPSHOT"
+version in ThisBuild := "17.9"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.9
+
+* Adds `showAliasPaths` to `ShowParameters`
+
 ## 17.8
 
 * Bump CAPI models to 15.9.14

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -203,6 +203,7 @@ trait ShowParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { thi
   def showAtoms  = StringParameter("show-atoms")
   def showSection = BoolParameter("show-section")
   def showStats = BoolParameter("show-stats")
+  def showAliasPaths = BoolParameter("show-alias-paths")
 }
 
 trait ShowReferencesParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>

--- a/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
@@ -8,9 +8,19 @@ class ContentApiQueryTest extends FlatSpec with Matchers  {
       "/profile/robert-berry?show-fields=all"
   }
 
+  "ItemQuery" should "be similarly excellent when asked to show alias paths" in {
+    ItemQuery("profile/justin-pinner").showAliasPaths(true).getUrl("") shouldEqual
+      "/profile/justin-pinner?show-alias-paths=true"
+  }
+
   "SearchQuery" should "also be excellent" in {
     SearchQuery().tag("profile/robert-berry").showElements("all").contentType("article").getUrl("") shouldEqual
       "/search?tag=profile%2Frobert-berry&show-elements=all&type=article"
+  }
+
+  "SearchQuery" should "not be perturbed when asked to show alias paths" in {
+    SearchQuery().tag("profile/justin-pinner").showElements("all").showAliasPaths(true).contentType("article").getUrl("") shouldEqual
+      "/search?tag=profile%2Fjustin-pinner&show-elements=all&show-alias-paths=true&type=article"
   }
 
   "SectionsQuery" should "be beautiful" in {

--- a/client/version.sbt
+++ b/client/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "17.9-SNAPSHOT"
+version in ThisBuild := "17.9"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "17.9-SNAPSHOT"
+version in ThisBuild := "17.9"


### PR DESCRIPTION
## What does this change?
Adds the `showAliasPaths` parameter.

## How to test
Construct a search or itemSearch query that uses the showAliasPaths parameter. If the content has aliasPaths they will be returned.

## How can we measure success?
Internal processes e.g. Crier will be able to retrieve the current alias paths associated with content for downstream de-cache notifications.

## Have we considered potential risks?
There is no risk associated with this change.

## Images
N/A
