### PR TITLE
Add `Format` to the Scala CAPI client

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 17.10
+
+* Add `Format` to `CapiModelEnrichment`.
+  * This adds the `Design`, `Display` and `Theme` traits to be consumed by platforms.
+
 ## 17.9
 
 * Adds `showAliasPaths` to `ShowParameters`

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -187,7 +187,7 @@ object CapiModelEnrichment {
 
       val predicates: List[(ContentFilter, Display)] = List(
         isImmersive -> ImmersiveDisplay,
-        isShowcase -> ShowcaseDisplay,
+//        isShowcase -> ShowcaseDisplay,
         isNumberedList -> NumberedListDisplay
       )
 

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -1,10 +1,35 @@
 package com.gu.contentapi.client.utils
 
 import com.gu.contentapi.client.model.v1._
+import com.gu.contentapi.client.utils.format._
+
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 
 object CapiModelEnrichment {
+
+  type ContentFilter = Content => Boolean
+
+  def getFromPredicate[T](content: Content, predicates: List[(ContentFilter, T)]): Option[T] =
+    predicates.collectFirst { case (predicate, t) if predicate(content) => t }
+
+  def tagExistsWithId(tagId: String): ContentFilter = c => c.tags.exists(tag => tag.id == tagId)
+
+  def isLiveBloggingNow: ContentFilter = c => c.fields.flatMap(_.liveBloggingNow).contains(true)
+
+  val isImmersive: ContentFilter = c => c.fields.flatMap(_.displayHint).contains("immersive")
+
+  val isMedia: ContentFilter = c => tagExistsWithId("type/audio")(c) || tagExistsWithId("type/video")(c) || tagExistsWithId("type/gallery")(c)
+
+  val isReview: ContentFilter = c => tagExistsWithId("tone/reviews")(c) || tagExistsWithId("tone/livereview")(c) || tagExistsWithId("tone/albumreview")(c)
+
+  val isComment: ContentFilter = c => tagExistsWithId("tone/comment")(c) || tagExistsWithId("tone/letters")(c)
+
+  val isPhotoEssay: ContentFilter = c => c.fields.flatMap(_.displayHint).contains("photoessay")
+
+  val isLiveBlog: ContentFilter = c => isLiveBloggingNow(c) && tagExistsWithId("tone/minutebyminute")(c)
+
+  val isDeadBlog: ContentFilter = c => !isLiveBloggingNow(c) && tagExistsWithId("tone/minutebyminute")(c)
 
   implicit class RichCapiDateTime(val cdt: CapiDateTime) extends AnyVal {
     def toOffsetDateTime: OffsetDateTime = OffsetDateTime.parse(cdt.iso8601)
@@ -18,27 +43,9 @@ object CapiModelEnrichment {
 
     def designType: DesignType = {
 
-      val defaultDesignType = Article
+      val defaultDesignType: DesignType = Article
 
-      type ContentFilter = Content => Boolean
-
-      val isImmersive: ContentFilter = c => c.fields.flatMap(_.displayHint).contains("immersive")
-
-      def tagExistsWithId(tagId: String): ContentFilter = c => c.tags.exists(tag => tag.id == tagId)
-
-      val isMedia: ContentFilter = c => tagExistsWithId("type/audio")(c) || tagExistsWithId("type/video")(c) || tagExistsWithId("type/gallery")(c)
-
-      val isReview: ContentFilter = c => tagExistsWithId("tone/reviews")(c) || tagExistsWithId("tone/livereview")(c) || tagExistsWithId("tone/albumreview")(c)
-
-      def isComment: ContentFilter = c => tagExistsWithId("tone/comment")(c) || tagExistsWithId("tone/letters")(c)
-
-      def liveBloggingNow: Boolean = content.fields.flatMap(_.liveBloggingNow).contains(true)
-
-      val liveBlog: ContentFilter = liveBloggingNow && tagExistsWithId("tone/minutebyminute")(_)
-
-      val deadBlog: ContentFilter = !liveBloggingNow && tagExistsWithId("tone/minutebyminute")(_)
-
-      val predicates: List[(ContentFilter, DesignType)] = List (
+      val predicates: List[(ContentFilter, DesignType)] = List(
         tagExistsWithId("tone/advertisement-features") -> AdvertisementFeature,
         tagExistsWithId("tone/matchreports") -> MatchReport,
         tagExistsWithId("tone/quizzes") -> Quiz,
@@ -51,12 +58,96 @@ object CapiModelEnrichment {
         tagExistsWithId("tone/analysis") -> Analysis,
         isComment -> Comment,
         tagExistsWithId("tone/features") -> Feature,
-        liveBlog -> Live,
-        deadBlog -> Article
+        isLiveBlog -> Live,
+        isDeadBlog -> Article
       )
 
-      val result = predicates.collectFirst { case (predicate, design) if predicate(content) => design }
+      val result = getFromPredicate(content, predicates)
       result.getOrElse(defaultDesignType)
     }
   }
+
+  implicit class RenderingFormat(val content: Content) extends AnyVal {
+
+    def design: Design = {
+
+      val defaultDesign: Design = ArticleDesign
+
+      val predicates: List[(ContentFilter, Design)] = List(
+        tagExistsWithId("artanddesign/series/guardian-print-shop") -> PrintShopDesign,
+        tagExistsWithId("tone/matchreports") -> MatchReportDesign,
+        isMedia -> MediaDesign,
+        isReview -> ReviewDesign,
+        tagExistsWithId("tone/analysis") -> AnalysisDesign,
+        isComment -> CommentDesign,
+        tagExistsWithId("tone/features") -> FeatureDesign,
+        tagExistsWithId("tone/recipes") -> RecipeDesign,
+        tagExistsWithId("tone/matchreports") -> MatchReportDesign,
+        tagExistsWithId("tone/interview") -> InterviewDesign,
+        tagExistsWithId("tone/editorials") -> EditorialDesign,
+        tagExistsWithId("tone/quizzes") -> QuizDesign,
+        isPhotoEssay -> PhotoEssayDesign,
+        isLiveBlog -> LiveBlogDesign,
+        isDeadBlog -> DeadBlogDesign
+      )
+
+      val result = getFromPredicate(content, predicates)
+      result.getOrElse(defaultDesign)
+    }
+
+    def theme: Theme = {
+      val defaultTheme: Theme = NewsPillar
+
+      val specialReportTags: Set[String] = Set(
+        "business/series/undercover-in-the-chicken-industry",
+        "business/series/britains-debt-timebomb",
+        "world/series/this-is-europe",
+        "environment/series/the-polluters",
+        "news/series/hsbc-files",
+        "news/series/panama-papers",
+        "us-news/homan-square",
+        "uk-news/series/the-new-world-of-work",
+        "world/series/the-new-arrivals",
+        "news/series/nauru-files",
+        "us-news/series/counted-us-police-killings",
+        "australia-news/series/healthcare-in-detention",
+        "society/series/this-is-the-nhs"
+      )
+
+      def isPillar(pillar: String): ContentFilter = c => c.pillarName.contains(pillar)
+
+      val isSpecialReport: ContentFilter = c => c.tags.exists(t => specialReportTags(t.id))
+      val isOpinion: ContentFilter = c => isComment(c) && isPillar("News")(c) || isPillar("Opinion")(c)
+
+      val predicates: List[(ContentFilter, Theme)] = List(
+        isOpinion -> OpinionPillar,
+        isPillar("Sport") -> SportPillar,
+        isPillar("Culture") -> CulturePillar,
+        isPillar("Lifestyle") -> LifestylePillar,
+        isSpecialReport -> SpecialReport,
+        tagExistsWithId("tone/advertisement-features") -> Labs,
+      )
+
+      val result = getFromPredicate(content, predicates)
+      result.getOrElse(defaultTheme)
+    }
+
+    def display: Display = {
+
+      val defaultDisplay = StandardDisplay
+
+      // TODO: Handle Display.Showcase.
+      //  Could be done outside client if appropriate.
+      val predicates: List[(ContentFilter, Display)] = List(
+        isImmersive -> ImmersiveDisplay,
+      )
+
+      val result = getFromPredicate(content, predicates)
+      result.getOrElse(defaultDisplay)
+    }
+
+  }
+
+}
+
 }

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -187,7 +187,7 @@ object CapiModelEnrichment {
 
       val predicates: List[(ContentFilter, Display)] = List(
         isImmersive -> ImmersiveDisplay,
-//        isShowcase -> ShowcaseDisplay,
+        isShowcase -> ShowcaseDisplay,
         isNumberedList -> NumberedListDisplay
       )
 

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -75,6 +75,8 @@ object CapiModelEnrichment {
 
       val isPhotoEssay: ContentFilter = content => content.fields.flatMap(_.displayHint).contains("photoessay")
 
+      val isInteractive: ContentFilter = content => content.`type` == ContentType.Interactive
+
       val predicates: List[(ContentFilter, Design)] = List(
         tagExistsWithId("artanddesign/series/guardian-print-shop") -> PrintShopDesign,
         isMedia -> MediaDesign,
@@ -88,6 +90,7 @@ object CapiModelEnrichment {
         tagExistsWithId("tone/interview") -> InterviewDesign,
         tagExistsWithId("tone/editorials") -> EditorialDesign,
         tagExistsWithId("tone/quizzes") -> QuizDesign,
+        isInteractive -> InteractiveDesign,
         isPhotoEssay -> PhotoEssayDesign,
         isLiveBlog -> LiveBlogDesign,
         isDeadBlog -> DeadBlogDesign

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -25,8 +25,6 @@ object CapiModelEnrichment {
 
   val isReview: ContentFilter = content => tagExistsWithId("tone/reviews")(content) || tagExistsWithId("tone/livereview")(content) || tagExistsWithId("tone/albumreview")(content)
 
-  val isCommentDesign: ContentFilter = content => tagExistsWithId("tone/comment")(content) || tagExistsWithId("tone/letters")(content)
-
   val isLiveBlog: ContentFilter = content => isLiveBloggingNow(content) && tagExistsWithId("tone/minutebyminute")(content)
 
   val isDeadBlog: ContentFilter = content => !isLiveBloggingNow(content) && tagExistsWithId("tone/minutebyminute")(content)
@@ -43,6 +41,7 @@ object CapiModelEnrichment {
 
     def designType: DesignType = {
 
+      val isComment: ContentFilter = content => tagExistsWithId("tone/comment")(content) || tagExistsWithId("tone/letters")(content)
       val defaultDesignType: DesignType = Article
 
       val predicates: List[(ContentFilter, DesignType)] = List(
@@ -56,7 +55,7 @@ object CapiModelEnrichment {
         isMedia -> Media,
         isReview -> Review,
         tagExistsWithId("tone/analysis") -> Analysis,
-        isCommentDesign -> Comment,
+        isComment -> Comment,
         tagExistsWithId("tone/features") -> Feature,
         isLiveBlog -> Live,
         isDeadBlog -> Article
@@ -81,7 +80,8 @@ object CapiModelEnrichment {
         isMedia -> MediaDesign,
         isReview -> ReviewDesign,
         tagExistsWithId("tone/analysis") -> AnalysisDesign,
-        isCommentDesign -> CommentDesign,
+        tagExistsWithId("tone/comment") -> CommentDesign,
+        tagExistsWithId("tone/letters") -> LetterDesign,
         tagExistsWithId("tone/features") -> FeatureDesign,
         tagExistsWithId("tone/recipes") -> RecipeDesign,
         tagExistsWithId("tone/matchreports") -> MatchReportDesign,
@@ -119,7 +119,7 @@ object CapiModelEnrichment {
       def isPillar(pillar: String): ContentFilter = content => content.pillarName.contains(pillar)
 
       val isSpecialReport: ContentFilter = content => content.tags.exists(t => specialReportTags(t.id))
-      val isOpinion: ContentFilter = content => (isCommentDesign(content) && isPillar("News")(content)) ||
+      val isOpinion: ContentFilter = content => (tagExistsWithId("tone/comment")(content) && isPillar("News")(content)) ||
         isPillar("Opinion")(content)
       val isCulture: ContentFilter = content => isPillar("Arts")(content) || isPillar("Books")(content)
 

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -27,8 +27,6 @@ object CapiModelEnrichment {
 
   val isCommentDesign: ContentFilter = content => tagExistsWithId("tone/comment")(content) || tagExistsWithId("tone/letters")(content)
 
-  val isPhotoEssay: ContentFilter = content => content.fields.flatMap(_.displayHint).contains("photoessay")
-
   val isLiveBlog: ContentFilter = content => isLiveBloggingNow(content) && tagExistsWithId("tone/minutebyminute")(content)
 
   val isDeadBlog: ContentFilter = content => !isLiveBloggingNow(content) && tagExistsWithId("tone/minutebyminute")(content)
@@ -71,13 +69,15 @@ object CapiModelEnrichment {
 
   implicit class RenderingFormat(val content: Content) extends AnyVal {
 
+
     def design: Design = {
 
       val defaultDesign: Design = ArticleDesign
 
+      val isPhotoEssay: ContentFilter = content => content.fields.flatMap(_.displayHint).contains("photoessay")
+
       val predicates: List[(ContentFilter, Design)] = List(
         tagExistsWithId("artanddesign/series/guardian-print-shop") -> PrintShopDesign,
-        tagExistsWithId("tone/matchreports") -> MatchReportDesign,
         isMedia -> MediaDesign,
         isReview -> ReviewDesign,
         tagExistsWithId("tone/analysis") -> AnalysisDesign,
@@ -128,7 +128,7 @@ object CapiModelEnrichment {
         isPillar("Sport") -> SportPillar,
         isCulture -> CulturePillar,
         isPillar("Lifestyle") -> LifestylePillar,
-        isSpecialReport -> SpecialReport,
+        isSpecialReport -> SpecialReportTheme,
         tagExistsWithId("tone/advertisement-features") -> Labs,
       )
 

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -140,9 +140,9 @@ object CapiModelEnrichment {
 
       val defaultDisplay = StandardDisplay
 
-      def hasShowcaseImage: ContentFilter = c => {
+      def hasShowcaseImage: ContentFilter = content => {
         val hasShowcaseImage = for {
-          blocks <- c.blocks
+          blocks <- content.blocks
           main <- blocks.main
           mainMedia = main.elements.head
           imageTypeData <- mainMedia.imageTypeData

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
@@ -16,5 +16,6 @@ case object MatchReportDesign extends Design
 case object InterviewDesign extends Design
 case object EditorialDesign extends Design
 case object QuizDesign extends Design
+case object InteractiveDesign extends Design
 case object PhotoEssayDesign extends Design
 case object PrintShopDesign extends Design

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
@@ -1,0 +1,20 @@
+package com.gu.contentapi.client.utils.format
+
+sealed trait Design
+
+case object ArticleDesign extends Design
+case object MediaDesign extends Design
+case object ReviewDesign extends Design
+case object AnalysisDesign extends Design
+case object CommentDesign extends Design
+case object LetterDesign extends Design
+case object FeatureDesign extends Design
+case object LiveBlogDesign extends Design
+case object DeadBlogDesign extends Design
+case object RecipeDesign extends Design
+case object MatchReportDesign extends Design
+case object InterviewDesign extends Design
+case object EditorialDesign extends Design
+case object QuizDesign extends Design
+case object PhotoEssayDesign extends Design
+case object PrintShopDesign extends Design

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Display.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Display.scala
@@ -1,0 +1,9 @@
+package com.gu.contentapi.client.utils.format
+
+sealed trait Display
+
+case object StandardDisplay extends Display
+case object ImmersiveDisplay extends Display
+case object ShowcaseDisplay extends Display
+case object NumberedListDisplay extends Display
+case object ColumnDisplay extends Display

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Theme.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Theme.scala
@@ -1,0 +1,14 @@
+package com.gu.contentapi.client.utils.format
+
+sealed trait Theme
+
+sealed trait Pillar extends Theme
+sealed trait Special extends Theme
+
+case object NewsPillar extends Pillar
+case object OpinionPillar extends Pillar
+case object SportPillar extends Pillar
+case object CulturePillar extends Pillar
+case object LifestylePillar extends Pillar
+case object SpecialReport extends Special
+case object Labs extends Special

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Theme.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Theme.scala
@@ -10,5 +10,5 @@ case object OpinionPillar extends Pillar
 case object SportPillar extends Pillar
 case object CulturePillar extends Pillar
 case object LifestylePillar extends Pillar
-case object SpecialReport extends Special
+case object SpecialReportTheme extends Special
 case object Labs extends Special

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -275,7 +275,7 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     val f = fixture
     when(f.tag.id) thenReturn "tone/letters"
 
-    f.content.design shouldEqual CommentDesign
+    f.content.design shouldEqual LetterDesign
   }
 
   it should "have a design of 'FeatureDesign' when tag tone/features is present" in {
@@ -375,14 +375,6 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     val f = fixture
     when(f.content.pillarName) thenReturn Some("News")
     when(f.tag.id) thenReturn "tone/comment"
-
-    f.content.theme shouldEqual OpinionPillar
-  }
-
-  it should "return a theme of 'OpinionPillar' when tag tone/letters is present and has a pillarNAme of 'News'" in {
-    val f = fixture
-    when(f.content.pillarName) thenReturn Some("News")
-    when(f.tag.id) thenReturn "tone/letters"
 
     f.content.theme shouldEqual OpinionPillar
   }

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -1,6 +1,6 @@
 package com.gu.contentapi.client.model.utils
 
-import com.gu.contentapi.client.model.v1.{Block, BlockElement, Blocks, Content, ContentFields, Tag}
+import com.gu.contentapi.client.model.v1._
 import com.gu.contentapi.client.utils.CapiModelEnrichment._
 import com.gu.contentapi.client.utils._
 import com.gu.contentapi.client.utils.format._
@@ -177,10 +177,33 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     val tag: Tag = mock[Tag]
     val fields: ContentFields = mock[ContentFields]
 
+    val blocks: Blocks = mock[Blocks]
+    val main: Block = mock[Block]
+    val blockElement: BlockElement = mock[BlockElement]
+    val imageTypeData: ImageElementFields = mock[ImageElementFields]
+
+    val element: Element = mock[Element]
+    val asset: Asset = mock[Asset]
+    val assetFields: AssetFields = mock[AssetFields]
+
     when(fields.displayHint) thenReturn None
     when(content.tags) thenReturn List(tag)
     when(content.fields) thenReturn None
     when(content.pillarName) thenReturn None
+
+    when(content.blocks) thenReturn None
+    when(blocks.main) thenReturn None
+    when(main.elements) thenReturn Seq(blockElement)
+    when(blockElement.imageTypeData) thenReturn None
+
+    when(content.elements) thenReturn None
+    when(element.relation) thenReturn ""
+    when(element.`type`) thenReturn ElementType.Text // Are these acceptable empty values?
+    when(element.assets) thenReturn Seq(asset)
+    when(asset.`type`) thenReturn AssetType.Image // Are these acceptable empty values?
+    when(asset.typeData) thenReturn None
+    when(assetFields.role) thenReturn None
+
   }
 
   behavior of "Format.design"
@@ -503,21 +526,29 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.display shouldEqual ImmersiveDisplay
   }
 
-  ignore should "return a display of 'ShowcaseDisplay' when a showcaseImage is set" in {
+  it should "return a display of 'ShowcaseDisplay' when a showcaseImage is set" in {
     val f = fixture
-    val blocks: Blocks = mock[Blocks]
-    val main: Block = mock[Block]
-    val elements: Seq[BlockElement] = mock[Seq[BlockElement]]
-    val imageTypeData: ImageTypeSpecifier = mock[ImageTypeSpecifier]
+
+    when(f.content.blocks) thenReturn Some(f.blocks)
+    when(f.blocks.main) thenReturn Some(f.main)
+    when(f.blockElement.imageTypeData) thenReturn Some(f.imageTypeData)
+    when(f.imageTypeData.role) thenReturn Some("showcase")
+
+    f.content.display shouldEqual ShowcaseDisplay
 
   }
 
-  ignore should "return a display of 'ShowcaseDisplay' when a showcaseEmbed is set" in {
+  it should "return a display of 'ShowcaseDisplay' when a showcaseEmbed is set" in {
     val f = fixture
-    val blocks: Blocks = mock[Blocks]
-    val main: Block = mock[Block]
-    val elements: Seq[BlockElement] = mock[Seq[BlockElement]]
-    val imageTypeData: ImageTypeSpecifier = mock[ImageTypeSpecifier]
+
+    when(f.content.elements) thenReturn Some(scala.collection.Seq(f.element))
+    when(f.element.relation) thenReturn "main"
+    when(f.element.`type`) thenReturn ElementType.Embed
+    when(f.asset.`type`) thenReturn AssetType.Embed
+    when(f.asset.typeData) thenReturn Some(f.assetFields)
+    when(f.assetFields.role) thenReturn Some("showcase")
+
+    f.content.display shouldEqual ShowcaseDisplay
 
   }
 

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -190,6 +190,7 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     when(content.tags) thenReturn List(tag)
     when(content.fields) thenReturn None
     when(content.pillarName) thenReturn None
+    when(content.`type`) thenReturn ContentType.Article
 
     when(content.blocks) thenReturn None
     when(blocks.main) thenReturn None
@@ -318,6 +319,13 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     when(f.tag.id) thenReturn "tone/quizzes"
 
     f.content.design shouldEqual QuizDesign
+  }
+
+  it should "have a design of 'InteractiveDesign' when ContentType is Interactive" in {
+    val f = fixture
+    when(f.content.`type`) thenReturn ContentType.Interactive
+
+    f.content.design shouldEqual InteractiveDesign
   }
 
   it should "have a design of 'PhotoEssayDesign' when displayHint contains photoessay" in {

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -180,6 +180,7 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     when(fields.displayHint) thenReturn None
     when(content.tags) thenReturn List(tag)
     when(content.fields) thenReturn None
+    when(content.pillarName) thenReturn None
   }
 
   behavior of "Format.design"
@@ -394,7 +395,6 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
   it should "return a theme of 'SpecialReportTheme' when tag business/series/undercover-in-the-chicken-industry is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "business/series/undercover-in-the-chicken-industry"
-
     f.content.theme shouldEqual SpecialReportTheme
   }
 

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -1,14 +1,17 @@
 package com.gu.contentapi.client.model.utils
 
-import com.gu.contentapi.client.model.v1.{Content, ContentFields, Tag}
+import com.gu.contentapi.client.model.v1.{Block, BlockElement, Blocks, Content, ContentFields, Tag}
 import com.gu.contentapi.client.utils.CapiModelEnrichment._
 import com.gu.contentapi.client.utils._
+import com.gu.contentapi.client.utils.format._
 import org.mockito.Mockito._
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.mockito.MockitoSugar
 
+import javax.imageio.ImageTypeSpecifier
 
-class CapiModelEnrichmentTest extends FlatSpec with MockitoSugar with Matchers {
+
+class CapiModelEnrichmentDesignTypeTest extends FlatSpec with MockitoSugar with Matchers {
 
   def fixture = new {
     val content: Content = mock[Content]
@@ -20,56 +23,56 @@ class CapiModelEnrichmentTest extends FlatSpec with MockitoSugar with Matchers {
     when(content.fields) thenReturn None
   }
 
-  it should  "have a designType of 'Media' when tag type/video is present" in {
+  it should "have a designType of 'Media' when tag type/video is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "type/video"
 
     f.content.designType shouldEqual Media
   }
 
-  it should  "have a designType of 'Media' when tag type/audio is present" in {
+  it should "have a designType of 'Media' when tag type/audio is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "type/audio"
 
     f.content.designType shouldEqual Media
   }
 
-  it should  "have a designType of 'Media' when tag type/gallery is present" in {
+  it should "have a designType of 'Media' when tag type/gallery is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "type/gallery"
 
     f.content.designType shouldEqual Media
   }
 
-  it should  "have a designType of 'Review' when tag tone/reviews is present" in {
+  it should "have a designType of 'Review' when tag tone/reviews is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "tone/reviews"
 
     f.content.designType shouldEqual Review
   }
 
-  it should  "have a designType of 'Review' when tag tone/livereview is present" in {
+  it should "have a designType of 'Review' when tag tone/livereview is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "tone/livereview"
 
     f.content.designType shouldEqual Review
   }
 
-  it should  "have a designType of 'Review' when tag tone/albumreview is present" in {
+  it should "have a designType of 'Review' when tag tone/albumreview is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "tone/albumreview"
 
     f.content.designType shouldEqual Review
   }
 
-  it should  "have a designType of 'Comment' when tag tone/comment is present" in {
+  it should "have a designType of 'Comment' when tag tone/comment is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "tone/comment"
 
     f.content.designType shouldEqual Comment
   }
 
-  it should  "have a designType of 'Live' when tag tone/minutebyminute is present and is liveblogging" in {
+  it should "have a designType of 'Live' when tag tone/minutebyminute is present and is liveblogging" in {
     val f = fixture
 
     when(f.tag.id) thenReturn "tone/minutebyminute"
@@ -79,7 +82,7 @@ class CapiModelEnrichmentTest extends FlatSpec with MockitoSugar with Matchers {
     f.content.designType shouldEqual Live
   }
 
-  it should  "have a designType of 'Article' when tag tone/minutebyminute is present but not live anymore" in {
+  it should "have a designType of 'Article' when tag tone/minutebyminute is present but not live anymore" in {
     val f = fixture
 
     when(f.tag.id) thenReturn "tone/minutebyminute"
@@ -89,7 +92,7 @@ class CapiModelEnrichmentTest extends FlatSpec with MockitoSugar with Matchers {
     f.content.designType shouldEqual Article
   }
 
-  it should  "have a designType of 'Feature' when tag tone/features is present" in {
+  it should "have a designType of 'Feature' when tag tone/features is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "tone/features"
 
@@ -97,7 +100,7 @@ class CapiModelEnrichmentTest extends FlatSpec with MockitoSugar with Matchers {
   }
 
 
-  it should  "have a designType of 'Analysis' when tag tone/analysis is present" in {
+  it should "have a designType of 'Analysis' when tag tone/analysis is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "tone/analysis"
 
@@ -165,5 +168,370 @@ class CapiModelEnrichmentTest extends FlatSpec with MockitoSugar with Matchers {
   }
 
 
+}
+
+class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matchers {
+
+  def fixture = new {
+    val content: Content = mock[Content]
+    val tag: Tag = mock[Tag]
+    val fields: ContentFields = mock[ContentFields]
+
+    when(fields.displayHint) thenReturn None
+    when(content.tags) thenReturn List(tag)
+    when(content.fields) thenReturn None
+  }
+
+  behavior of "Format.design"
+
+  it should "have a design of 'PrintShopDesign' when tag artanddesign/series/guardian-print-shop is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "artanddesign/series/guardian-print-shop"
+
+    f.content.design shouldEqual PrintShopDesign
+  }
+
+  it should "have a design of 'MediaDesign' when tag type/audio is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "type/audio"
+
+    f.content.design shouldEqual MediaDesign
+  }
+
+  it should "have a design of 'MediaDesign' when tag type/video is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "type/video"
+
+    f.content.design shouldEqual MediaDesign
+  }
+
+  it should "have a design of 'MediaDesign' when tag type/gallery is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "type/gallery"
+
+    f.content.design shouldEqual MediaDesign
+  }
+
+  it should "have a design of 'ReviewDesign' when tag tone/reviews is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/reviews"
+
+    f.content.design shouldEqual ReviewDesign
+  }
+
+  it should "have a design of 'ReviewDesign' when tag tone/livereview is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/livereview"
+
+    f.content.design shouldEqual ReviewDesign
+  }
+
+  it should "have a design of 'ReviewDesign' when tag tone/albumreview is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/albumreview"
+
+    f.content.design shouldEqual ReviewDesign
+  }
+
+  it should "have a design of 'AnalysisDesign' when tag tone/analysis is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/analysis"
+
+    f.content.design shouldEqual AnalysisDesign
+  }
+
+  it should "have a design of 'CommentDesign' when tag tone/comment is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/comment"
+
+    f.content.design shouldEqual CommentDesign
+  }
+
+  it should "have a design of 'CommentDesign' when tag tone/letters is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/letters"
+
+    f.content.design shouldEqual CommentDesign
+  }
+
+  it should "have a design of 'FeatureDesign' when tag tone/features is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/features"
+
+    f.content.design shouldEqual FeatureDesign
+  }
+
+  it should "have a design of 'RecipeDesign' when tag tone/recipes is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/recipes"
+
+    f.content.design shouldEqual RecipeDesign
+  }
+
+  it should "have a design of 'MatchReportDesign' when tag tone/matchreports is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/matchreports"
+
+    f.content.design shouldEqual MatchReportDesign
+  }
+
+  it should "have a design of 'InterviewDesign' when tag tone/interview is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/interview"
+
+    f.content.design shouldEqual InterviewDesign
+  }
+
+  it should "have a design of 'EditorialDesign' when tag tone/editorials is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/editorials"
+
+    f.content.design shouldEqual EditorialDesign
+  }
+
+  it should "have a design of 'QuizDesign' when tag tone/quizzes is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/quizzes"
+
+    f.content.design shouldEqual QuizDesign
+  }
+
+  it should "have a design of 'PhotoEssayDesign' when displayHint contains photoessay" in {
+    val f = fixture
+    when(f.fields.displayHint) thenReturn Some("photoessay")
+    when(f.content.fields) thenReturn Some(f.fields)
+
+    f.content.design shouldEqual PhotoEssayDesign
+  }
+
+  it should "have a design of 'LiveBlogDesign' when tag tone/minutebyminute is present and is liveblogging" in {
+    val f = fixture
+
+    when(f.tag.id) thenReturn "tone/minutebyminute"
+    when(f.fields.liveBloggingNow) thenReturn Some(true)
+    when(f.content.fields) thenReturn Some(f.fields)
+
+    f.content.design shouldEqual LiveBlogDesign
+  }
+
+  it should "have a design of 'DeadBlogDesign' when tag tone/minutebyminute is present but not live anymore" in {
+    val f = fixture
+
+    when(f.tag.id) thenReturn "tone/minutebyminute"
+    when(f.fields.liveBloggingNow) thenReturn None
+    when(f.content.fields) thenReturn Some(f.fields)
+
+    f.content.design shouldEqual DeadBlogDesign
+  }
+
+  it should "have a design of 'ArticleDesign' when no predicates match" in {
+    val f = fixture
+
+    f.content.design shouldEqual ArticleDesign
+  }
+
+  //test one example of filters being applied in priority order
+  it should "return a design of 'MediaDesign' over a design of 'CommentDesign' where tags for both are present'" in {
+    val content = mock[Content]
+    val commentTag = mock[Tag]
+    val videoTag = mock[Tag]
+
+    when(commentTag.id) thenReturn "tone/comment"
+    when(videoTag.id) thenReturn "type/video"
+    when(content.fields) thenReturn None
+    when(content.tags) thenReturn List(commentTag, videoTag)
+
+    content.design shouldEqual MediaDesign
+
+  }
+
+  behavior of "Format.theme"
+
+  it should "return a theme of 'OpinionPillar' when tag tone/comment is present and has a pillar of 'NewsPillar'" in {
+    val f = fixture
+    when(f.content.pillarName) thenReturn Some("News")
+    when(f.tag.id) thenReturn "tone/comment"
+
+    f.content.theme shouldEqual OpinionPillar
+  }
+
+  it should "return a theme of 'OpinionPillar' when tag tone/letters is present and has a pillarNAme of 'News'" in {
+    val f = fixture
+    when(f.content.pillarName) thenReturn Some("News")
+    when(f.tag.id) thenReturn "tone/letters"
+
+    f.content.theme shouldEqual OpinionPillar
+  }
+
+  it should "return a theme of 'SportPillar' when has a pillarName of 'Sport'" in {
+    val f = fixture
+    when(f.content.pillarName) thenReturn Some("Sport")
+
+    f.content.theme shouldEqual SportPillar
+  }
+
+  it should "return a theme of 'CulturePillar' when has a pillarName of 'Arts'" in {
+    val f = fixture
+    when(f.content.pillarName) thenReturn Some("Arts")
+
+    f.content.theme shouldEqual CulturePillar
+  }
+
+  it should "return a theme of 'CulturePillar' when has a pillarName of 'Books'" in {
+    val f = fixture
+    when(f.content.pillarName) thenReturn Some("Books")
+
+    f.content.theme shouldEqual CulturePillar
+  }
+
+  it should "return a theme of 'LifestylePillar' when has a pillarName of 'Lifestyle'" in {
+    val f = fixture
+    when(f.content.pillarName) thenReturn Some("Lifestyle")
+
+    f.content.theme shouldEqual LifestylePillar
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag business/series/undercover-in-the-chicken-industry is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "business/series/undercover-in-the-chicken-industry"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag business/series/britains-debt-timebomb is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "business/series/britains-debt-timebomb"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag world/series/this-is-europe is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "world/series/this-is-europe"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag environment/series/the-polluters is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "environment/series/the-polluters"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag news/series/hsbc-files is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "news/series/hsbc-files"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag news/series/panama-papers is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "news/series/panama-papers"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag us-news/homan-square is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "us-news/homan-square"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag uk-news/series/the-new-world-of-work is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "uk-news/series/the-new-world-of-work"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag world/series/the-new-arrivals is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "world/series/the-new-arrivals"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag news/series/nauru-files is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "news/series/nauru-files"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag us-news/series/counted-us-police-killings is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "us-news/series/counted-us-police-killings"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag australia-news/series/healthcare-in-detention is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "australia-news/series/healthcare-in-detention"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'SpecialReportTheme' when tag society/series/this-is-the-nhs is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "society/series/this-is-the-nhs"
+
+    f.content.theme shouldEqual SpecialReportTheme
+  }
+
+  it should "return a theme of 'Labs' when tag tone/advertisement-features is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/advertisement-features"
+
+    f.content.theme shouldEqual Labs
+  }
+
+  it should "return a theme of 'NewsPillar' when no predicates match" in {
+    val f = fixture
+    f.content.theme shouldEqual NewsPillar
+  }
+
+  behavior of "Format.display"
+
+  it should "return a display of 'ImmersiveDisplay' when a displayHint of immersive is set" in {
+    val f = fixture
+    when(f.content.fields) thenReturn Some(f.fields)
+    when(f.fields.displayHint) thenReturn Some("immersive")
+    f.content.display shouldEqual ImmersiveDisplay
+  }
+
+  ignore should "return a display of 'ShowcaseDisplay' when a showcaseImage is set" in {
+    val f = fixture
+    val blocks: Blocks = mock[Blocks]
+    val main: Block = mock[Block]
+    val elements: Seq[BlockElement] = mock[Seq[BlockElement]]
+    val imageTypeData: ImageTypeSpecifier = mock[ImageTypeSpecifier]
+
+  }
+
+  ignore should "return a display of 'ShowcaseDisplay' when a showcaseEmbed is set" in {
+    val f = fixture
+    val blocks: Blocks = mock[Blocks]
+    val main: Block = mock[Block]
+    val elements: Seq[BlockElement] = mock[Seq[BlockElement]]
+    val imageTypeData: ImageTypeSpecifier = mock[ImageTypeSpecifier]
+
+  }
+
+  it should "return a display of 'NumberedListDisplay' when a displayHint of numberedList is set" in {
+    val f = fixture
+    when(f.content.fields) thenReturn Some(f.fields)
+    when(f.fields.displayHint) thenReturn Some("numberedList")
+    f.content.display shouldEqual NumberedListDisplay
+  }
+
+  it should "return a display of 'StandardDisplay' when no predicates are set" in {
+    val f = fixture
+
+    f.content.display shouldEqual StandardDisplay
+  }
 
 }

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -8,9 +8,6 @@ import org.mockito.Mockito._
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.mockito.MockitoSugar
 
-import javax.imageio.ImageTypeSpecifier
-
-
 class CapiModelEnrichmentDesignTypeTest extends FlatSpec with MockitoSugar with Matchers {
 
   def fixture = new {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Rendering platforms have moved to use the `Format` type to describe the
format that rendered data should take. This includes three specific
fields:
 - `Display`
 - `Design`
 - `Theme (Pillar/Special)`

Currently the platforms handle the decision logic around how to
construct this object on platform but ideally this will be done upstream
in order to standardise across platforms and to simplify the parsing of
data.

Here  I upstream the `Format` type to the CAPI Scala client.

### Changes:
- Introduce the `Display`, `Theme` and `Design` traits and their
associated `case object`s.
- Refactor `CAPIModelEnrichment` to move code shared by `RichContent`
and `Format` to the upper scope.
- Reproduce the decision logic used by platforms to construct the
`Format` object.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
I've added unit tests for this and they can be run using whatever testing process you prefer e.g. `sbt test`

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Improved DevX for anyone working with the `Format` type, and ideally tidy refactors of the platform code to use this instead of multiple checks and flags.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
I don't think there are any risks. This doesn't affect the raw data and shouldn't remove backwards compatibility.
