### PR TITLE
Bump to CAPI models 15.10.0 (evolving url aliasPaths update)

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 17.10
+
+* Bump CAPI models to 15.10.0
+  * updates `aliasPaths` definition to include `ceasedToBeCanonicalAt` datetime
+
 ## 17.9
 
 * Adds `showAliasPaths` to `ShowParameters`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "15.9.14"
+  val CapiModelsVersion = "15.10.0"
 
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,


### PR DESCRIPTION
## What does this change?
Pick up the latest (15.10.0) CAPI models so we can relay `aliasPaths` complete with their respective `path` and `ceasedToBeCanonicalAt` DateTime values to clients that need them.

## How to test
Check that clients can be updated to use this version of the library and receive the data as expected.

## How can we measure success?
If e.g. frontend, MAPI and Pubflow can see the new data, we're succeeding.

## Have we considered potential risks?
This is a change to an as yet unreleased feature so no production services should be too bothered by it yet. Plus it requires a specific by clients to bring it in to service, so risk is low.

## Images
N/A
