### PR TITLE
Enable paths as a search parameter

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.12
+
+* Add support for `paths` SearchQuery parameter (e.g. `search?paths=path/one,path/two`)
+
 ## 17.11
 
 * Bump CAPI models to 15.10.0

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -241,7 +241,7 @@ trait FilterParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { t
 trait FilterExtendedParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
   def tag = StringParameter("tag")
   def ids = StringParameter("ids")
-  def paths: StringParameter = StringParameter("paths")
+  def paths = StringParameter("paths")
   def rights = StringParameter("rights")
   def leadContent = StringParameter("lead-content")
   def fromDate = DateParameter("from-date")

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -241,6 +241,7 @@ trait FilterParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { t
 trait FilterExtendedParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
   def tag = StringParameter("tag")
   def ids = StringParameter("ids")
+  def paths: StringParameter = StringParameter("paths")
   def rights = StringParameter("rights")
   def leadContent = StringParameter("lead-content")
   def fromDate = DateParameter("from-date")

--- a/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
@@ -23,6 +23,11 @@ class ContentApiQueryTest extends FlatSpec with Matchers  {
       "/search?tag=profile%2Fjustin-pinner&show-elements=all&show-alias-paths=true&type=article"
   }
 
+  "SearchQuery" should "accept paths as a parameter" in {
+    SearchQuery().paths("path/one,path/two").getUrl("") shouldEqual
+      "/search?paths=path%2Fone%2Cpath%2Ftwo"
+  }
+
   "SectionsQuery" should "be beautiful" in {
     SectionsQuery().getUrl("") shouldEqual "/sections"
   }


### PR DESCRIPTION
## What does this change?
The evolving URLs work means that content item IDs won't necessarily match the path that content is served on any longer. If this occurs, searching for `ids` alone, for example `search?ids=alpha/bravo/charlie,delta/echo/foxtrot` would miss `delta/echo/foxtrot` if its URL had evolved to e.g. `delta/echo/golf`. 

This PR adds support for a `paths` search parameter such that switching out `search?ids=` with `search?paths=` will ensure both items are located.

## How to test
I have tested this change locally as follows;
```
$ sbt
.
sbt:root> project defaultClient
.
sbt:content-api-client-default> console
.
scala> val client = new GuardianContentClient("YOUR-API-KEY")
.
val pathSearch = ContentApiClient.search.paths("info/developer-blog/2016/dec/22/parental-advisory-implicit-content,world/2021/mar/19/norwegian-pm-erna-solberg-investigated-for-covid-rules-breach")
.
Await.result(client.getResponse(pathSearch), 5.seconds)
```
which returns (trimmed for brevity)
```
Content(world/2021/mar/19/norwegian-pm-erna-solberg-investigated-for-covid-rules-breach,Article,...
Content(info/developer-blog/2016/dec/22/parental-advisory-implicit-content,Article,...
```

## How can we measure success?
Ophan can report on page views accurately when URLs have evolved.

## Have we considered potential risks?
This is an opt-in for consumers to update to the latest client. If they don't adopt this release then their services may not find the results they expect.

## Images
N/A
