### PR TITLE
Release content-api-client-aws too

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import Dependencies._
 /* --------------------------------------------------------------------- */
 
 lazy val root = (project in file("."))
-  .aggregate(client, defaultClient)
+  .aggregate(client, defaultClient, aws)
   .settings(commonSettings, publishSettings)
   .settings(
     skip in publish    := true,


### PR DESCRIPTION
`content-api-client-aws` has not been released for the last 3 years and doesn't include a Scala 2.13 build.  This PR will release this library with every other client release.