### PR TITLE
Fix Photo Essays in Format

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -21,6 +21,8 @@ object CapiModelEnrichment {
 
   val isImmersive: ContentFilter = content => displayHintExistsWithName("immersive")(content)
 
+  val isPhotoEssay: ContentFilter = content => displayHintExistsWithName("photoEssay")(content)
+
   val isMedia: ContentFilter = content => tagExistsWithId("type/audio")(content) || tagExistsWithId("type/video")(content) || tagExistsWithId("type/gallery")(content)
 
   val isReview: ContentFilter = content => tagExistsWithId("tone/reviews")(content) || tagExistsWithId("tone/livereview")(content) || tagExistsWithId("tone/albumreview")(content)
@@ -73,8 +75,6 @@ object CapiModelEnrichment {
 
       val defaultDesign: Design = ArticleDesign
 
-      val isPhotoEssay: ContentFilter = content => content.fields.flatMap(_.displayHint).contains("photoessay")
-
       val isInteractive: ContentFilter = content => content.`type` == ContentType.Interactive
 
       val predicates: List[(ContentFilter, Design)] = List(
@@ -84,6 +84,7 @@ object CapiModelEnrichment {
         tagExistsWithId("tone/analysis") -> AnalysisDesign,
         tagExistsWithId("tone/comment") -> CommentDesign,
         tagExistsWithId("tone/letters") -> LetterDesign,
+        isPhotoEssay -> PhotoEssayDesign,
         tagExistsWithId("tone/interview") -> InterviewDesign,
         tagExistsWithId("tone/features") -> FeatureDesign,
         tagExistsWithId("tone/recipes") -> RecipeDesign,
@@ -91,7 +92,6 @@ object CapiModelEnrichment {
         tagExistsWithId("tone/editorials") -> EditorialDesign,
         tagExistsWithId("tone/quizzes") -> QuizDesign,
         isInteractive -> InteractiveDesign,
-        isPhotoEssay -> PhotoEssayDesign,
         isLiveBlog -> LiveBlogDesign,
         isDeadBlog -> DeadBlogDesign
       )
@@ -143,6 +143,14 @@ object CapiModelEnrichment {
 
       val defaultDisplay = StandardDisplay
 
+      // We separate this out from the previous isImmersive to prevent breaking the legacy designType when adding
+      // the logic currently handled on Frontend. isGallery relies on Frontend metadata and so won't be added here
+      // https://github.com/guardian/frontend/blob/e71dc1c521672b28399811c59331e0c2c713bf00/common/app/model/content.scala#L86
+
+      val isImmersiveDisplay: ContentFilter = content =>
+        isImmersive(content) ||
+          isPhotoEssay(content)
+
       def hasShowcaseImage: ContentFilter = content => {
         val hasShowcaseImage = for {
           blocks <- content.blocks
@@ -189,7 +197,7 @@ object CapiModelEnrichment {
       val isNumberedList: ContentFilter = displayHintExistsWithName("numberedList")
 
       val predicates: List[(ContentFilter, Display)] = List(
-        isImmersive -> ImmersiveDisplay,
+        isImmersiveDisplay -> ImmersiveDisplay,
         isShowcase -> ShowcaseDisplay,
         isNumberedList -> NumberedListDisplay
       )

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -325,9 +325,9 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.design shouldEqual InteractiveDesign
   }
 
-  it should "have a design of 'PhotoEssayDesign' when displayHint contains photoessay" in {
+  it should "have a design of 'PhotoEssayDesign' when displayHint contains photoEssay" in {
     val f = fixture
-    when(f.fields.displayHint) thenReturn Some("photoessay")
+    when(f.fields.displayHint) thenReturn Some("photoEssay")
     when(f.content.fields) thenReturn Some(f.fields)
 
     f.content.design shouldEqual PhotoEssayDesign
@@ -385,6 +385,17 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     when(content.tags) thenReturn List(interviewTag, featureTag)
 
     content.design shouldEqual InterviewDesign
+
+  }
+
+  it should "return a design of 'PhotoEssayDesign' over a design of 'FeatureDesign' where information for both is present'" in {
+    val f = fixture
+
+    when(f.tag.id) thenReturn "tone/features"
+    when(f.fields.displayHint) thenReturn Some("photoEssay")
+    when(f.content.fields) thenReturn Some(f.fields)
+
+    f.content.design shouldEqual PhotoEssayDesign
 
   }
 
@@ -534,6 +545,13 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     val f = fixture
     when(f.content.fields) thenReturn Some(f.fields)
     when(f.fields.displayHint) thenReturn Some("immersive")
+    f.content.display shouldEqual ImmersiveDisplay
+  }
+
+  it should "return a display of 'ImmersiveDisplay' when a displayHint of photoEssay is set" in {
+    val f = fixture
+    when(f.content.fields) thenReturn Some(f.fields)
+    when(f.fields.displayHint) thenReturn Some("photoEssay")
     f.content.display shouldEqual ImmersiveDisplay
   }
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Photo Essays needed the display hint to be camel case, not lower case. I've added a test for this and the correct design when both the feature tag and the photo essay display hint are present.
I've also made them always an Immersive display to keep parity with [what is currently in Frontend](https://github.com/guardian/frontend/blob/e71dc1c521672b28399811c59331e0c2c713bf00/common/app/model/content.scala#L86).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
`sbt test`


