### PR TITLE
Fix Theme assigned to letters with a News pillar

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.15
+
+* Correct Letters content to have `OpinionPillar` instead of `NewsPillar` when tag is present.
+
 ## 17.14
 
 * Fix bug with ordering of predicates in Design enrichment for Features and PhotoEssays

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -122,8 +122,10 @@ object CapiModelEnrichment {
       def isPillar(pillar: String): ContentFilter = content => content.pillarName.contains(pillar)
 
       val isSpecialReport: ContentFilter = content => content.tags.exists(t => specialReportTags(t.id))
-      val isOpinion: ContentFilter = content => (tagExistsWithId("tone/comment")(content) && isPillar("News")(content)) ||
-        isPillar("Opinion")(content)
+      val isOpinion: ContentFilter = content =>
+        (tagExistsWithId("tone/comment")(content) && isPillar("News")(content)) ||
+          (tagExistsWithId("tone/letters")(content) && isPillar("News")(content)) ||
+          isPillar("Opinion")(content)
       val isCulture: ContentFilter = content => isPillar("Arts")(content) || isPillar("Books")(content)
 
       val predicates: List[(ContentFilter, Theme)] = List(

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -409,6 +409,14 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.theme shouldEqual OpinionPillar
   }
 
+  it should "return a theme of 'OpinionPillar' when tag tone/letters is present and has a pillar of 'NewsPillar'" in {
+    val f = fixture
+    when(f.content.pillarName) thenReturn Some("News")
+    when(f.tag.id) thenReturn "tone/letters"
+
+    f.content.theme shouldEqual OpinionPillar
+  }
+
   it should "return a theme of 'SportPillar' when has a pillarName of 'Sport'" in {
     val f = fixture
     when(f.content.pillarName) thenReturn Some("Sport")


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
When a piece of content is a Letter (based on the tags) we need to override the assigned theme to be `OpinionTheme`.

Here I've added this in, duplicating the same approach that we use for Opinion pieces where the same situation occurs.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
`sbt test`
