### PR TITLE
Bump scala client to latest version of CAPI model

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 17.16
+
+* Bump CAPI models to 15.10.2
+  * updates `blocks` field to include code type elements on the body
+
 ## 17.15
 
 * Correct Letters content to have `OpinionPillar` instead of `NewsPillar` when tag is present.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "15.10.0"
+  val CapiModelsVersion = "15.10.2"
 
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "17.16-SNAPSHOT"
+version in ThisBuild := "17.16"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "17.16"
+version in ThisBuild := "17.16-SNAPSHOT"


### PR DESCRIPTION
## What does this change?
Updates scala client to use latest version of the CAPI model (15.10.2). This model adds code type elements to the body block.

In the `apple-news` repository, the scala client and CAPI model had fallen out of sync, leading to the following error when trying to access a code element (which existed in the model but not the client):

```
java.lang.NoSuchMethodError: com.gu.contentapi.client.model.v1.BlockElement$.apply$default$22()Lscala/Option;
	at com.gu.contentapi.json.CirceDecoders$$anon$23.$anonfun$apply$1691(CirceDecoders.scala:101)
```
	
This error is resolved by bringing the model and client back in sync.

## How to test
Tested locally using a snapshot version of this scala client.

## How can we measure success?
Apple news repo will build successfully with version 15.10.2 of CAPI model.
