### PR TITLE
Import CAPI models 16.1.0 and upgrade thrift to 0.13.0

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 17.18
 
-* Bump CAPI models to 16.0.1 (upgrades thrift to 0.13.0)
+* Bump CAPI models to 16.1.0 (upgrades thrift to 0.13.0)
 * Bump our own import of thrift to 0.13.0 also
 
 ## 17.17

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 17.17
+
+* Bump CAPI models to 16.0.0 (upgrades thrift to 0.13.0)
+* Bump our own import of thrift to 0.13.0 also
+
 ## 17.16
 
 * Bump CAPI models to 15.10.2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,11 +3,13 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "15.10.2"
+  val CapiModelsVersion = "16.0.0-RC2"
 
+  // Note: keep libthrift at a version functionally compatible with that used in CAPI models
+  // if build failures occur due to eviction / sbt-assembly mergeStrategy errors
   val clientDeps = Seq(
     "com.gu" %% "content-api-models-scala" % CapiModelsVersion,
-    "org.apache.thrift" % "libthrift" % "0.12.0",
+    "org.apache.thrift" % "libthrift" % "0.13.0",
     "org.scalatest" %% "scalatest" % "3.0.8" % "test" exclude("org.mockito", "mockito-core"),
     "org.slf4j" % "slf4j-api" % "1.7.25",
     "org.mockito" % "mockito-all" % "1.10.19" % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "16.0.0-RC2"
+  val CapiModelsVersion = "16.0.0"
 
   // Note: keep libthrift at a version functionally compatible with that used in CAPI models
   // if build failures occur due to eviction / sbt-assembly mergeStrategy errors

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "16.0.0"
+  val CapiModelsVersion = "16.1.0"
 
   // Note: keep libthrift at a version functionally compatible with that used in CAPI models
   // if build failures occur due to eviction / sbt-assembly mergeStrategy errors

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "17.17-RC3"
+version in ThisBuild := "17.17"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "17.17-SNAPSHOT"
+version in ThisBuild := "17.17-RC3"


### PR DESCRIPTION
## What does this change?
This is to test the upgrade of thrift to 0.13.0 in content-api-models (now released as 16.1.0). We also bumped our own import of thrift to 0.13.0 to maintain consistency.

## How to test
Once assembled, tested and deployed incorporate into our own applications.
 
## How can we measure success?
Does it build? Our own test coverage _should_ be sufficient to be confident that it will work as advertised.

## Have we considered potential risks?
Serialisation failures / weirdness may occur - but our test coverage should be sufficient to trap that prior to releasing this library as a new version.

## Images
![beaker_panic](https://user-images.githubusercontent.com/690395/115545844-2e47fe00-a29c-11eb-8d42-db132937f517.gif)
