### PR TITLE
Enable snapshot and candidate releasing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,8 +116,8 @@ lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
     case v if v == snapshotReleaseType => snapshotReleaseType.toUpperCase
   }.getOrElse("PRODUCTION")
 
-  SimpleReader.readLine(s"This will be a $releaseType release. Continue? [Y/n]") match {
-    case Some(v) if v.toUpperCase == "Y" => // we don't care about the value - it's a flow control mechanism
+  SimpleReader.readLine(s"This will be a $releaseType release. Continue? [y/N]: ") match {
+    case Some(v) if Seq("Y", "YES").contains(v.toUpperCase) => // we don't care about the value - it's a flow control mechanism
     case _ => sys.error(s"Release aborted by user!")
   }
   // we haven't changed state, just pass it on if we haven't thrown an error from above

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,32 @@
 import sbt.Keys._
 import ReleaseTransformations._
 import Dependencies._
+import sbtrelease.Utilities.Yes
+import sbtrelease.{Version, versionFormatError}
 
 /* --------------------------------------------------------------------- */
 
+val candidateReleaseType = "candidate"
+val candidateReleaseSuffix = "-RC1"
+val snapshotReleaseType = "snapshot"
+val snapshotReleaseSuffix = "-SNAPSHOT"
+
+lazy val versionSettingsMaybe = {
+  // Set by e.g. sbt -DRELEASE_TYPE=candidate|snapshot.
+  // For production release, don't set a RELEASE_TYPE variable
+  sys.props.get("RELEASE_TYPE").map {
+    case v if v == candidateReleaseType => candidateReleaseSuffix
+    case v if v == snapshotReleaseType => snapshotReleaseSuffix
+  }.map { suffix =>
+    releaseVersion := {
+      ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
+    }
+  }.toSeq
+}
+
 lazy val root = (project in file("."))
   .aggregate(client, defaultClient)
-  .settings(commonSettings, publishSettings)
+  .settings(commonSettings, versionSettingsMaybe, publishSettings)
   .settings(
     skip in publish    := true,
     releaseVersionFile := baseDirectory.value / "version.sbt",
@@ -22,8 +42,11 @@ lazy val defaultClient = (project in file("client-default"))
   .dependsOn(client)
   .settings(commonSettings, defaultClientSettings, publishSettings)
 
+// we apply versionSettingsMaybe to aws too because this project is always released in isolation
+// from the others - and we _might_ want to put out a snapsot or release candidate for that (TBC).
+// Bear this in mind if we begin releasing aws in sync with the others
 lazy val aws = (project in file("aws"))
-  .settings(commonSettings, awsSettings, publishSettings)
+  .settings(commonSettings, awsSettings, versionSettingsMaybe, publishSettings)
 
 /* --------------------------------------------------------------------- */
 
@@ -66,29 +89,103 @@ lazy val awsSettings: Seq[Setting[_]] = Seq(
   libraryDependencies ++= awsDeps,
 )
 
+lazy val canOverwrite: Boolean = {
+  // allow overwriting of SNAPSHOT releases ONLY
+  sys.props.get("RELEASE_TYPE").exists {
+    case v if v == snapshotReleaseType => true
+    case _ => false
+  }
+}
+
 lazy val publishSettings: Seq[Setting[_]] = Seq(
   resolvers += Resolver.sonatypeRepo("public"),
   pomIncludeRepository := { _ => false },
   publishTo := sonatypePublishToBundle.value,
+  publishConfiguration := publishConfiguration.value.withOverwrite(canOverwrite),
   publishMavenStyle := true,
   publishArtifact in Test := false,
   releaseVcsSign := true,
-  releaseProcess := releaseSteps,
+  releaseProcess := releaseProcessSteps,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  pgpSecretRing := pgpPublicRing.value
+  pgpSecretRing := pgpPublicRing.value  // <-- I wonder if this is causing the pgp errors some of us struggle with 🤔
 )
 
-lazy val releaseSteps: Seq[ReleaseStep] = Seq(
-  checkSnapshotDependencies,
-  inquireVersions,
-  runClean,
-  runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
-  releaseStepCommandAndRemaining("+publishSigned"),
-  releaseStepCommand("sonatypeBundleRelease"),
-  setNextVersion,
-  commitNextVersion,
-  pushChanges
-)
+lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
+  val releaseType = sys.props.get("RELEASE_TYPE").map {
+    case v if v == candidateReleaseType => candidateReleaseType.toUpperCase
+    case v if v == snapshotReleaseType => snapshotReleaseType.toUpperCase
+  }.getOrElse("PRODUCTION")
+
+  SimpleReader.readLine(s"This will be a $releaseType release. Continue? [Y/n]") match {
+    case Some(v) if v.toUpperCase == "Y" => // we don't care about the value - it's a flow control mechanism
+    case _ => sys.error(s"Release aborted by user!")
+  }
+  // we haven't changed state, just pass it on if we haven't thrown an error from above
+  st
+})
+
+lazy val releaseProcessSteps: Seq[ReleaseStep] = {
+  val commonSteps = Seq(
+    checkReleaseType,
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    runTest
+  )
+
+  val prodSteps: Seq[ReleaseStep] = Seq(
+    setReleaseVersion,
+    commitReleaseVersion,
+    tagRelease,
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
+    setNextVersion,
+    commitNextVersion,
+    pushChanges
+  )
+
+  /*
+  SNAPSHOT versions are published directly to Sonatype snapshot repo and no local bundle is assembled
+  Also, we cannot use `sonatypeBundleUpload` or `sonatypeRelease` commands which are usually wrapped up
+  within a call to `sonatypeBundleRelease` (https://github.com/xerial/sbt-sonatype#publishing-your-artifact).
+
+  Therefore SNAPSHOT versions are not promoted to Maven Central and consumers will have to ensure they have the
+  appropriate resolver entry in their build.sbt, e.g.
+
+  resolvers += Resolver.sonatypeRepo("snapshots")
+
+  To make this work, start SBT with the snapshot releaseType;
+    sbt -DRELEASE_TYPE=snapshot
+
+  */
+  val snapshotSteps: Seq[ReleaseStep] = Seq(
+    releaseStepCommandAndRemaining("+publishSigned")
+  )
+
+  /*
+  Release Candidate assemblies can be published to Sonatype and Maven.
+
+  To make this work, start SBT with the candidate releaseType;
+    sbt -DRELEASE_TYPE=candidate
+
+  This gets around the "problem" of sbt-sonatype assuming that a -SNAPSHOT build should not be delivered to Maven.
+
+  In this mode, the version number will be presented as e.g. 1.2.3-RC1, but the git tagging and version-updating
+  steps are not triggered, so it's up to the developer to keep track of what was released and manipulate subsequent
+  release and next versions appropriately.
+  */
+  val candidateSteps: Seq[ReleaseStep] = Seq(
+    setReleaseVersion,
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
+    setNextVersion,
+  )
+
+  // remember to set with sbt -DRELEASE_TYPE=snapshot|candidate if running a non-prod release
+  commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
+    case Some(v) if v == snapshotReleaseType => snapshotSteps // this deploys -SNAPSHOT build to sonatype snapshot repo only
+    case Some(v) if v == candidateReleaseType => candidateSteps // this enables a release candidate build to sonatype and Maven
+    case None => prodSteps  // our normal deploy route
+  })
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import sbt.Keys._
 import ReleaseTransformations._
 import Dependencies._
-import sbtrelease.Utilities.Yes
 import sbtrelease.{Version, versionFormatError}
 
 /* --------------------------------------------------------------------- */
@@ -116,7 +115,7 @@ lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
     case v if v == snapshotReleaseType => snapshotReleaseType.toUpperCase
   }.getOrElse("PRODUCTION")
 
-  SimpleReader.readLine(s"This will be a $releaseType release. Continue? [y/N]: ") match {
+  SimpleReader.readLine(s"This will be a $releaseType release. Continue? (y/n) [N]: ") match {
     case Some(v) if Seq("Y", "YES").contains(v.toUpperCase) => // we don't care about the value - it's a flow control mechanism
     case _ => sys.error(s"Release aborted by user!")
   }
@@ -159,7 +158,9 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
 
   */
   val snapshotSteps: Seq[ReleaseStep] = Seq(
-    releaseStepCommandAndRemaining("+publishSigned")
+    setReleaseVersion,
+    releaseStepCommandAndRemaining("+publishSigned"),
+    setNextVersion
   )
 
   /*
@@ -178,7 +179,7 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
     setReleaseVersion,
     releaseStepCommandAndRemaining("+publishSigned"),
     releaseStepCommand("sonatypeBundleRelease"),
-    setNextVersion,
+    setNextVersion
   )
 
   // remember to set with sbt -DRELEASE_TYPE=snapshot|candidate if running a non-prod release

--- a/docs/release.md
+++ b/docs/release.md
@@ -15,6 +15,20 @@ sbt -DCAPI_TEST_KEY=a-valid-api-key 'release cross'
 The api key needs to be a production key with tier `Internal`. You can obtain a key from `https://bonobo.capi.gutools.co.uk/`
 
 
+#### Non-production releases:
+If you intend to publish a release candidate or snapshot build (e.g. from a WIP code branch) for testing the library in another application prior to releasing your changes to production - which can be useful when testing the effects of upgrading dependencies etc - you should also send the appropriate value in a parameter:
+```
+sbt -DCAPI_TEST_KEY=a-valid-api-key -DRELEASE_TYPE=candidate|snapshot 'release cross'
+```
+
+The value you pass drives the version numbering hints and which release steps to execute. For example a snapshot release is not published to Maven Central but a release candidate is. 
+
+These options also influence the post-release steps such as updating the version.sbt file and committing it to git. Neither the candidate nor the snapshot releases include those steps. 
+
+You'll still be prompted to enter the version number you're releasing and it is currently left to the developer to ensure the version number is suitable. You can always check what's already available on maven here: https://mvnrepository.com/artifact/com.gu/content-api-client   
+
+For a "normal" production release be sure not to have a RELEASE_TYPE reference hanging around - quit and restart sbt without the parameter if you do.
+
 #### Releasing content-api-client-aws:
 This project does not depend on content-api-client.
 ```


### PR DESCRIPTION
## What does this change?
Sometimes we want to test changes in the CAPI scala client(s) without necessarily having to commit to a 100% good-to-go public release. These changes aim to allow us to release SNAPSHOT builds to Sonatype's snapshots repo, or release candidate releases to both Sonatype and Maven.

In these new scenarios we don't commit `version.sbt` changes or release tags back to git automatically, so we're free to repeat the release process as needed - something that is especially helpful when trying to debug permission problems e.g. with gpg signing etc.

When released, we would then be able to ingest these versions into our own consumer applications to verify that everything is good, and public consumers would better understand that those releases are not considered to be production-ready.

## How to test
start sbt
`$ sbt -DCAPI_TEST_KEY=***** -DRELEASE_TYPE=snapshot|candidate`
issue the release command
`sbt:root > release cross`
you'll see either
`This will be a SNAPSHOT release. Continue? [y/N]:`
or
`This will be a CANDIDATE release. Continue? [y/N]:`
and be prompted to supply the release version
`Release version [17.17-SNAPSHOT] :`
or
`Release version [17.17-RC1] :`

When complete, changes made to your local `version.sbt` file should be left for you to manually commit or ignore.

All of this only applies when a -DRELEASE_TYPE= value is passed into sbt. For a production release the only addition is that it will still prompt you with
`This will be a PRODUCTION release. Continue? [y/N]:`
that you have to respond to.

## How can we measure success?
We can ship multiple SNAPSHOT and/or release candidate releases. Snapshot releases can be overwritten (e.g. we can release the same snapshot version multiple times, but release candidates can only be deployed once per version, so ensure to update as you go, e.g. -RC1, -RC2 etc.

## Have we considered potential risks?
Risk should be minimal but we will have the ability to expose non-production builds to the public in our release candidates, so those must be in good order from the point of view of their ability to cause upstream problems. 

## Images
![release](https://user-images.githubusercontent.com/690395/115698367-6f9fe280-a35c-11eb-981a-f5a66826b628.gif)

