### PR TITLE
Fix ordering of NumberedList display type

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -200,8 +200,8 @@ object CapiModelEnrichment {
 
       val predicates: List[(ContentFilter, Display)] = List(
         isImmersiveDisplay -> ImmersiveDisplay,
-        isShowcase -> ShowcaseDisplay,
-        isNumberedList -> NumberedListDisplay
+        isNumberedList -> NumberedListDisplay,
+        isShowcase -> ShowcaseDisplay
       )
 
       val result = getFromPredicate(content, predicates)

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -596,6 +596,21 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.display shouldEqual NumberedListDisplay
   }
 
+  it should "return a display of 'NumberedListDisplay' when a displayHint of numberedList is set and a showcase element is present" in {
+    val f = fixture
+    when(f.content.fields) thenReturn Some(f.fields)
+    when(f.fields.displayHint) thenReturn Some("numberedList")
+
+    when(f.content.elements) thenReturn Some(scala.collection.Seq(f.element))
+    when(f.element.relation) thenReturn "main"
+    when(f.element.`type`) thenReturn ElementType.Embed
+    when(f.asset.`type`) thenReturn AssetType.Embed
+    when(f.asset.typeData) thenReturn Some(f.assetFields)
+    when(f.assetFields.role) thenReturn Some("showcase")
+
+    f.content.display shouldEqual NumberedListDisplay
+  }
+
   it should "return a display of 'StandardDisplay' when no predicates are set" in {
     val f = fixture
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Numbered lists often (if not always) contain showcase media and can be considered (to some degree) to be a specific case of Showcase. As a result we need to make sure that the Numbered List predicate appears before the Showcase predicate to ensure that it can actually be reached.


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

`sbt test`

