### PR TITLE
Fix specificity of Special Reports

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -129,11 +129,11 @@ object CapiModelEnrichment {
       val isCulture: ContentFilter = content => isPillar("Arts")(content) || isPillar("Books")(content)
 
       val predicates: List[(ContentFilter, Theme)] = List(
+        isSpecialReport -> SpecialReportTheme,
         isOpinion -> OpinionPillar,
         isPillar("Sport") -> SportPillar,
         isCulture -> CulturePillar,
         isPillar("Lifestyle") -> LifestylePillar,
-        isSpecialReport -> SpecialReportTheme,
         tagExistsWithId("tone/advertisement-features") -> Labs
       )
 

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -535,6 +535,21 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.theme shouldEqual SpecialReportTheme
   }
 
+  it should "return a theme of 'SpecialReportTheme' when it is also an Opinion piece" in {
+
+    val content = mock[Content]
+    val commentTag = mock[Tag]
+    val specialReportTag = mock[Tag]
+
+
+    when(specialReportTag.id) thenReturn "society/series/this-is-the-nhs"
+    when(commentTag.id) thenReturn "tone/letters"
+    when(content.fields) thenReturn None
+    when(content.tags) thenReturn List(commentTag, specialReportTag)
+
+    content.theme shouldEqual SpecialReportTheme
+  }
+
   it should "return a theme of 'Labs' when tag tone/advertisement-features is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "tone/advertisement-features"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Special Reports should be the first predicate as they take priority over other themes. For example, prior to this articles with a tag for the Opinion pillar would return that instead of Special Report.

I've added a test for one specific combination of tags (`["society/series/this-is-the-nhs", "tone/letters"]`) and this now passes
