### PR TITLE
Make labs higher specificity

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -130,11 +130,11 @@ object CapiModelEnrichment {
 
       val predicates: List[(ContentFilter, Theme)] = List(
         isSpecialReport -> SpecialReportTheme,
+        tagExistsWithId("tone/advertisement-features") -> Labs,
         isOpinion -> OpinionPillar,
         isPillar("Sport") -> SportPillar,
         isCulture -> CulturePillar,
         isPillar("Lifestyle") -> LifestylePillar,
-        tagExistsWithId("tone/advertisement-features") -> Labs
       )
 
       val result = getFromPredicate(content, predicates)

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -557,6 +557,15 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.theme shouldEqual Labs
   }
 
+  it should "return a theme of 'Labs' when tag tone/advertisement-features is present and any pillarName is set" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/advertisement-features"
+    when(f.content.pillarName) thenReturn Some("Lifestyle")
+
+
+    f.content.theme shouldEqual Labs
+  }
+
   it should "return a theme of 'NewsPillar' when no predicates match" in {
     val f = fixture
     f.content.theme shouldEqual NewsPillar


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Making Labs more specific than general pillars to make sure that we don't ever set a Labs piece as a general Pillar.

To quote @mxdvl 
> If the Premier League pays for an article, it’s labs, not Sports


## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
This should reduce the risk of an advertisement not being branded as such.
