### PR TITLE
Update release doc branch from master to main

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@ Each has its own versioning and so they are released independently.
 #### Releasing content-api-client and content-api-client-default:
 In your PR, update `CHANGELOG.md` with a description of the change. Also update `version.sbt` if releasing a new major version. 
 
-Then to release (from master branch):
+Then to release (from main branch):
 ```
 sbt -DCAPI_TEST_KEY=a-valid-api-key 'release cross'
 ```


### PR DESCRIPTION
Tweak as part of `master` -> `main` change. I'll also update the TC build and Github default branch.