### PR TITLE
Bump priority of interactive design type

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -78,6 +78,7 @@ object CapiModelEnrichment {
       val isInteractive: ContentFilter = content => content.`type` == ContentType.Interactive
 
       val predicates: List[(ContentFilter, Design)] = List(
+        isInteractive -> InteractiveDesign,
         tagExistsWithId("artanddesign/series/guardian-print-shop") -> PrintShopDesign,
         isMedia -> MediaDesign,
         isReview -> ReviewDesign,
@@ -91,7 +92,6 @@ object CapiModelEnrichment {
         tagExistsWithId("tone/matchreports") -> MatchReportDesign,
         tagExistsWithId("tone/editorials") -> EditorialDesign,
         tagExistsWithId("tone/quizzes") -> QuizDesign,
-        isInteractive -> InteractiveDesign,
         isLiveBlog -> LiveBlogDesign,
         isDeadBlog -> DeadBlogDesign
       )


### PR DESCRIPTION
Small tweak to bump priority of interactive design type as there are cases where this is currently wrong. E.g.

~https://www.theguardian.com/australia-news/ng-interactive/2021/may/11/budget-speech-2021-australia-treasurer-josh-frydenberg-full-address-annotated-what-we-can-read-between-the-lines~ https://www.theguardian.com/politics/ng-interactive/2021/may/06/2021-elections-results-may-local-scottish-welsh-polls

Note, as format is new, I don't think there is a direct parallel to Frontend behaviour. I don't think Interactives can currently be displayed as other formats (in Frontend) but if you know better please correct me!