### PR TITLE
Bumping capi model version to 17.1.0

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 17.20
-* Bump CAPI models to 17.0.1
+* Bump CAPI models to 17.1.0
   * updates embed type elements to include 'caption' field
   
 ## 17.19

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.20
+* Bump CAPI models to 17.0.1
+  * updates embed type elements to include 'caption' field
+  
 ## 17.19
 
 * Bump CAPI models to 17.0.0

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "17.0.0"
+  val CapiModelsVersion = "17.0.1"
 
   // Note: keep libthrift at a version functionally compatible with that used in CAPI models
   // if build failures occur due to eviction / sbt-assembly mergeStrategy errors

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
 
-  val CapiModelsVersion = "17.0.1"
+  val CapiModelsVersion = "17.1.0"
 
   // Note: keep libthrift at a version functionally compatible with that used in CAPI models
   // if build failures occur due to eviction / sbt-assembly mergeStrategy errors


### PR DESCRIPTION
## What does this change?
Allows Capi to export the new caption on embed elements field to the outside world.
Further details on the change made to the Capi model can be found here[https://github.com/guardian/content-api-models/pull/203]

### Note: 
The latest version of CAPI models was 17.0.0 before my latest bump however CSC was using 15.10.2, so I don't know if there might be any breaking changes in this bump

