### PR TITLE
Remove This Is Europe tag from Special Reports

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -106,7 +106,6 @@ object CapiModelEnrichment {
       val specialReportTags: Set[String] = Set(
         "business/series/undercover-in-the-chicken-industry",
         "business/series/britains-debt-timebomb",
-        "world/series/this-is-europe",
         "environment/series/the-polluters",
         "news/series/hsbc-files",
         "news/series/panama-papers",

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -472,13 +472,6 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.theme shouldEqual SpecialReportTheme
   }
 
-  it should "return a theme of 'SpecialReportTheme' when tag world/series/this-is-europe is present" in {
-    val f = fixture
-    when(f.tag.id) thenReturn "world/series/this-is-europe"
-
-    f.content.theme shouldEqual SpecialReportTheme
-  }
-
   it should "return a theme of 'SpecialReportTheme' when tag environment/series/the-polluters is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "environment/series/the-polluters"


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This Is Europe is being removed as per request from CP.

Co-authored-by: OllysCoding  <9575458+OllysCoding@users.noreply.github.com>


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

`sbt test`