### PR TITLE
feat: Use `Design.NewsletterSignup` when `newsletter-sign-up` tag is present

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -49,6 +49,7 @@ object CapiModelEnrichment {
       val defaultDesignType: DesignType = Article
 
       val predicates: List[(ContentFilter, DesignType)] = List(
+        tagExistsWithId("info/newsletter-sign-up") -> NewsletterSignup,
         tagExistsWithId("tone/advertisement-features") -> AdvertisementFeature,
         tagExistsWithId("tone/matchreports") -> MatchReport,
         tagExistsWithId("tone/quizzes") -> Quiz,

--- a/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
@@ -18,3 +18,4 @@ case object GuardianView extends DesignType
 case object GuardianLabs extends DesignType
 case object Quiz extends DesignType
 case object AdvertisementFeature extends DesignType
+case object NewsletterSignup extends DesignType

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
@@ -20,3 +20,4 @@ case object InteractiveDesign extends Design
 case object PhotoEssayDesign extends Design
 case object PrintShopDesign extends Design
 case object ObituaryDesign extends Design
+case object NewsletterSignupDesign extends Design

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -164,6 +164,13 @@ class CapiModelEnrichmentDesignTypeTest extends FlatSpec with MockitoSugar with 
 
   }
 
+  it should "have a designType of 'NewsletterSignup' when tag info/newsletter-sign-up is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "info/newsletter-sign-up"
+
+    f.content.designType shouldEqual NewsletterSignup
+  }
+
 
 }
 


### PR DESCRIPTION
## What does this change?
Adds support for `Design.NewsletterSignup`. This is a new design type [recently added](https://github.com/guardian/libs/pull/291) to `Format` that should be used for any piece that includes the tag `info/newsletter-sign-up` (https://www.theguardian.com/info/newsletter-sign-up).

## Why?
These pages are currently a mix of [standard articles](https://www.theguardian.com/world/guardian-australia-morning-mail/2014/jun/24/-sp-guardian-australias-morning-mail-subscribe-by-email) and [interactive articles](https://www.theguardian.com/info/ng-interactive/2021/oct/20/sign-up-for-down-to-earth-the-best-way-to-make-sense-of-the-biggest-environment-stories), neither of which is ideal. Standard articles are a bit boring but easily maintained. Interactive articles are exciting but hard to maintain.

By creating our own content type we can ask DCR to render a whole new page which is both exciting and maintainable.

## A note on order
I've placed the check for this tag at the beginning of the array. Any article that contains this tag will be given `Design.NewsletterSignup`, regardless of any other tags added to it.
