### PR TITLE
Upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ A Scala client for the Guardian's [Content API](http://explorer.capi.gutools.co.
 Add the following line to your SBT build definition, and set the version number to be the latest from the [releases page](https://github.com/guardian/content-api-scala-client/releases):
 
 ```scala
-libraryDependencies += "com.gu" %% "content-api-client-default" % "x.y"
+libraryDependencies += "com.gu" %% "content-api-client-default" % "x.y.z"
 ```
 
-Please note, as of version 7.0, the content api scala client no longer supports java 7.
+Please note;
+
+- as of version 7.0, the content api scala client no longer supports java 7.
+
+- as of version 17.24.0 the content api scala client only supports scala 2.12+
 
 If you don't have an API key, go to [open-platform.theguardian.com/access/](http://open-platform.theguardian.com/access/) to get one. You will then need to create a new instance of the client and set the key:
 

--- a/client-default/version.sbt
+++ b/client-default/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "17.21-SNAPSHOT"
+ThisBuild / version := "17.24.0-SNAPSHOT"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,6 +1,13 @@
+# 17.24.0
+* Bump CAPI models to 17.3.0 to take advantage of upstream dependency updates
+* Switch to three part semantic versioning to bring into line with other projects  
+* This build should be functionally identical to 17.23 but updates to thrift *could* introduce unexpected effects
+* This build no longer supports Scala < 2.12 due to upstream dependencies also dropping support for earlier versions
+
 ## 17.23
 * Map old "immersive interactive" articles to display: standard, design: full page interactive
 * Map new "immersive interactive" articles to display: immersive, design: interactive, to use the new template
+
 ## 17.21
 * Remove This is Europe tag from Special Report in format
 

--- a/client/version.sbt
+++ b/client/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "17.21-SNAPSHOT"
+ThisBuild / version := "17.24.0-SNAPSHOT"

--- a/docs/release.md
+++ b/docs/release.md
@@ -16,14 +16,14 @@ The api key needs to be a production key with tier `Internal`. You can obtain a 
 
 
 #### Non-production releases:
-If you intend to publish a release candidate or snapshot build (e.g. from a WIP code branch) for testing the library in another application prior to releasing your changes to production - which can be useful when testing the effects of upgrading dependencies etc - you should also send the appropriate value in a parameter:
+If you intend to publish a beta or snapshot build (e.g. from a WIP code branch) for testing the library in another application prior to releasing your changes to production - which can be useful when testing the effects of upgrading dependencies etc - you should also send the appropriate value in a parameter:
 ```
-sbt -DCAPI_TEST_KEY=a-valid-api-key -DRELEASE_TYPE=candidate|snapshot 'release cross'
+sbt -DCAPI_TEST_KEY=a-valid-api-key -DRELEASE_TYPE=beta|snapshot 'release cross'
 ```
 
-The value you pass drives the version numbering hints and which release steps to execute. For example a snapshot release is not published to Maven Central but a release candidate is. 
+The value you pass drives the version numbering hints and which release steps to execute. For example a snapshot release is not published to Maven Central but a beta release is. 
 
-These options also influence the post-release steps such as updating the version.sbt file and committing it to git. Neither the candidate nor the snapshot releases include those steps. 
+These options also influence the post-release steps such as updating the version.sbt file and committing it to git. Neither the beta nor the snapshot releases include those steps. 
 
 You'll still be prompted to enter the version number you're releasing and it is currently left to the developer to ensure the version number is suitable. You can always check what's already available on maven here: https://mvnrepository.com/artifact/com.gu/content-api-client   
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.3.0-beta.2"
+  val capiModelsVersion = "17.3.0"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,27 +1,33 @@
 import sbt._
 
 object Dependencies {
-  val scalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
+  val scalaVersions = Seq("2.12.10", "2.13.1")
+  val capiModelsVersion = "17.3.0-beta.2"
+  val thriftVersion = "0.15.0"
+  val commonsCodecVersion = "1.10"
+  val scalaTestVersion = "3.0.8"
+  val slf4jVersion = "1.7.25"
+  val mockitoVersion = "1.10.19"
+  val okhttpVersion = "3.9.1"
+  val awsSdkVersion = "1.11.280"
 
-  val CapiModelsVersion = "17.1.0"
-
-  // Note: keep libthrift at a version functionally compatible with that used in CAPI models
+  // Note: keep libthrift at a version functionally compatible with that used in content-api-models
   // if build failures occur due to eviction / sbt-assembly mergeStrategy errors
   val clientDeps = Seq(
-    "com.gu" %% "content-api-models-scala" % CapiModelsVersion,
-    "org.apache.thrift" % "libthrift" % "0.13.0",
-    "commons-codec" % "commons-codec" % "1.10",
-    "org.scalatest" %% "scalatest" % "3.0.8" % "test" exclude("org.mockito", "mockito-core"),
-    "org.slf4j" % "slf4j-api" % "1.7.25",
-    "org.mockito" % "mockito-all" % "1.10.19" % "test"
+    "com.gu" %% "content-api-models-scala" % capiModelsVersion,
+    "org.apache.thrift" % "libthrift" % thriftVersion,
+    "commons-codec" % "commons-codec" % commonsCodecVersion,
+    "org.scalatest" %% "scalatest" % scalaTestVersion % "test" exclude("org.mockito", "mockito-core"),
+    "org.slf4j" % "slf4j-api" % slf4jVersion,
+    "org.mockito" % "mockito-all" % mockitoVersion % "test"
   )
 
   val defaultClientDeps = Seq(
-    "com.squareup.okhttp3" % "okhttp" % "3.9.1"
+    "com.squareup.okhttp3" % "okhttp" % okhttpVersion
   )
 
   val awsDeps = Seq(
-    "com.amazonaws" % "aws-java-sdk-core" % "1.11.280",
-    "org.scalatest" %% "scalatest" % "3.0.8" % "test"
+    "com.amazonaws" % "aws-java-sdk-core" % awsSdkVersion,
+    "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0-M2")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "17.24-SNAPSHOT"
+ThisBuild / version := "17.24.0-beta.1"


### PR DESCRIPTION
## What does this change?

This build brings in an updated version of content-api-models (see https://github.com/guardian/content-api-models/pull/210 for details) and also updates other dependencies including thrift and updated sbt plugins suited for the previously updated sbt 1.5.7 version.

## How to test

This library has been tested locally and then released as a beta for users to ensure it works as it should in their applications. We don't expect any functional differences to exist but the move to thrift 0.15.0 _may_ result in some changes that aren't immediately obvious.

[content-api-client 17.24.0-beta.0 for scala 2.12](https://repo1.maven.org/maven2/com/gu/content-api-client_2.12/17.24.0-beta.0/)
[content-api-client 17.24.0-beta.0 for scala 2.13](https://repo1.maven.org/maven2/com/gu/content-api-client_2.13/17.24.0-beta.0/)

## How can we measure success?

Consumer applications import this library and continue to compile & run uninterrupted.

## Have we considered potential risks?

If there are any subtle changes in data representations provided via Thrift, these may not be immediately obvious, and could lead to inconsistencies.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable
