### PR TITLE
Prioritize Interactive design type assignment in CapiModelEnrichment

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -89,7 +89,11 @@ object CapiModelEnrichment {
 
       val defaultDesign: Design = ArticleDesign
 
+      // The following method will make the first assignment that matches
+      // so, modifying order here could create unintended problems:
       val predicates: List[(ContentFilter, Design)] = List(
+        isFullPageInteractive -> FullPageInteractiveDesign,
+        isInteractive -> InteractiveDesign,
         tagExistsWithId("artanddesign/series/guardian-print-shop") -> PrintShopDesign,
         isMedia -> MediaDesign,
         isReview -> ReviewDesign,
@@ -104,8 +108,6 @@ object CapiModelEnrichment {
         tagExistsWithId("tone/matchreports") -> MatchReportDesign,
         tagExistsWithId("tone/editorials") -> EditorialDesign,
         tagExistsWithId("tone/quizzes") -> QuizDesign,
-        isFullPageInteractive -> FullPageInteractiveDesign,
-        isInteractive -> InteractiveDesign,
         isLiveBlog -> LiveBlogDesign,
         isDeadBlog -> DeadBlogDesign
       )

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -89,8 +89,8 @@ object CapiModelEnrichment {
 
       val defaultDesign: Design = ArticleDesign
 
-      // The following method will make the first assignment that matches
-      // so, modifying order here could create unintended problems:
+      // Note: only the first matching predicate will be picked.
+      // Modifying the order of predicates could create unintended problems:
       val predicates: List[(ContentFilter, Design)] = List(
         isFullPageInteractive -> FullPageInteractiveDesign,
         isInteractive -> InteractiveDesign,


### PR DESCRIPTION
## What does this change?

Changing the logic of the design assignment method to prioritize interactive design above feature designs

This allows us to remove logic in Frontend that forces interactive design if it was assigned incorrectly in CapiModelEnrichment: https://github.com/guardian/frontend/pull/23854

co-authored by: @OllysCoding and @mxdvl

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Look at a Feature + Interactive, it should now have `InteractiveDesign`, rather than `FeatureDesign`

## How can we measure success?

Removal of temporary downstream fixes. https://github.com/guardian/frontend/pull/23854

## Have we considered potential risks?

Yes, we’ve made it explicit that only a single Design can be matched