### PR TITLE
Added Newsletter tone tag

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -75,7 +75,8 @@ object CapiModelEnrichment {
         isComment -> Comment,
         tagExistsWithId("tone/features") -> Feature,
         isLiveBlog -> Live,
-        isDeadBlog -> Article
+        isDeadBlog -> Article,
+        tagExistsWithId("tone/newsletter-tone") -> Newsletter
       )
 
       val result = getFromPredicate(content, predicates)
@@ -109,7 +110,8 @@ object CapiModelEnrichment {
         tagExistsWithId("tone/editorials") -> EditorialDesign,
         tagExistsWithId("tone/quizzes") -> QuizDesign,
         isLiveBlog -> LiveBlogDesign,
-        isDeadBlog -> DeadBlogDesign
+        isDeadBlog -> DeadBlogDesign,
+        tagExistsWithId("tone/newsletter-tone") -> NewsletterDesign
       )
 
       val result = getFromPredicate(content, predicates)

--- a/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
@@ -19,3 +19,4 @@ case object GuardianLabs extends DesignType
 case object Quiz extends DesignType
 case object AdvertisementFeature extends DesignType
 case object NewsletterSignup extends DesignType
+case object Newsletter extends DesignType

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
@@ -22,3 +22,4 @@ case object PhotoEssayDesign extends Design
 case object PrintShopDesign extends Design
 case object ObituaryDesign extends Design
 case object NewsletterSignupDesign extends Design
+case object NewsletterDesign extends Design

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -171,6 +171,12 @@ class CapiModelEnrichmentDesignTypeTest extends FlatSpec with MockitoSugar with 
     f.content.designType shouldEqual NewsletterSignup
   }
 
+  it should "have a designType of 'Newsletter' when tag tone/newsletter-tone is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/newsletter-tone"
+
+    f.content.designType shouldEqual Newsletter
+  }  
 
 }
 
@@ -452,6 +458,13 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
 
     f.content.design shouldEqual ObituaryDesign
   }
+
+  it should "have a design of 'NewsletterDesign' when tag tone/newsletter-tone is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/newsletter-tone"
+
+    f.content.design shouldEqual NewsletterDesign
+  }  
 
   behavior of "Format.theme"
 


### PR DESCRIPTION
## What does this change?
For the launch of First edition (the updated Morning Briefing) on Monday 25th April, a new design tone is introduced for newsletters on fronts.  This will apply to all articles with the newsletter tone tag.

This PR is to support the new `Newsletter` tone and add the new `Newsletter` to `DesignType`.

## How to test

All tests passed.

## How can we measure success?

The library can set the design type of articles tagged with newsletter tone to `Newsletter` design type.
