### PR TITLE
Rework Modelling Of Newsletter Designs

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -61,7 +61,6 @@ object CapiModelEnrichment {
       val defaultDesignType: DesignType = Article
 
       val predicates: List[(ContentFilter, DesignType)] = List(
-        tagExistsWithId("info/newsletter-sign-up") -> NewsletterSignup,
         tagExistsWithId("tone/advertisement-features") -> AdvertisementFeature,
         tagExistsWithId("tone/matchreports") -> MatchReport,
         tagExistsWithId("tone/quizzes") -> Quiz,
@@ -93,6 +92,7 @@ object CapiModelEnrichment {
       // Note: only the first matching predicate will be picked.
       // Modifying the order of predicates could create unintended problems:
       val predicates: List[(ContentFilter, Design)] = List(
+        tagExistsWithId("info/newsletter-sign-up") -> NewsletterSignupDesign,
         isFullPageInteractive -> FullPageInteractiveDesign,
         isInteractive -> InteractiveDesign,
         tagExistsWithId("artanddesign/series/guardian-print-shop") -> PrintShopDesign,
@@ -111,7 +111,6 @@ object CapiModelEnrichment {
         tagExistsWithId("tone/quizzes") -> QuizDesign,
         isLiveBlog -> LiveBlogDesign,
         isDeadBlog -> DeadBlogDesign,
-        tagExistsWithId("tone/newsletter-tone") -> NewsletterDesign
       )
 
       val result = getFromPredicate(content, predicates)

--- a/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
@@ -18,5 +18,4 @@ case object GuardianView extends DesignType
 case object GuardianLabs extends DesignType
 case object Quiz extends DesignType
 case object AdvertisementFeature extends DesignType
-case object NewsletterSignup extends DesignType
 case object Newsletter extends DesignType

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
@@ -22,4 +22,3 @@ case object PhotoEssayDesign extends Design
 case object PrintShopDesign extends Design
 case object ObituaryDesign extends Design
 case object NewsletterSignupDesign extends Design
-case object NewsletterDesign extends Design

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -164,13 +164,6 @@ class CapiModelEnrichmentDesignTypeTest extends FlatSpec with MockitoSugar with 
 
   }
 
-  it should "have a designType of 'NewsletterSignup' when tag info/newsletter-sign-up is present" in {
-    val f = fixture
-    when(f.tag.id) thenReturn "info/newsletter-sign-up"
-
-    f.content.designType shouldEqual NewsletterSignup
-  }
-
   it should "have a designType of 'Newsletter' when tag tone/newsletter-tone is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "tone/newsletter-tone"
@@ -459,11 +452,11 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.design shouldEqual ObituaryDesign
   }
 
-  it should "have a design of 'NewsletterDesign' when tag tone/newsletter-tone is present" in {
+  it should "have a design of 'NewsletterSignupDesign' when tag info/newsletter-sign-up is present" in {
     val f = fixture
-    when(f.tag.id) thenReturn "tone/newsletter-tone"
+    when(f.tag.id) thenReturn "info/newsletter-sign-up"
 
-    f.content.design shouldEqual NewsletterDesign
+    f.content.design shouldEqual NewsletterSignupDesign
   }  
 
   behavior of "Format.theme"


### PR DESCRIPTION
## Why?

This is a rework of some of the model changes that were made to represent a couple of different newsletter features in #340 and #351. I _think_ there may have been a couple of unneeded additions made to `DesignType` and `Design`, primarily because it's not very clear what these two types are for or what the difference is between them. However, I will caveat that by saying that I'm not sure I've got the distinction correct, and I'm very happy to be told I've misunderstood things @oliverlloyd @waisingyiu or @rowannekabalan 😬. I've written up my understanding of the difference between them below.

### PR #340: NewsletterSignup

@oliverlloyd based on the description of this PR I believe the purpose was to introduce `Design.NewsletterSignup`, a new `Design` within the `Format` type for use with articles in DCR and AR? However this wasn't added to the list of predicates within the `RenderingFormat.design` method. I've now added it to the top of this list as described in your original PR. I've also added a test to cover this. Let me know if you think this is incorrect.

This PR also added `NewsletterSignup` to the old `DesignType` which I don't _think_ is used by DCR. I've removed it from this type but I'm less confident about this change - if it is indeed used by DCR somehow, or if it's required by Frontend for other purposes, let me know and I'll re-add it.

### PR #351: Newsletter

@waisingyiu I believe this PR was introduced to model newsletters cards on fronts, so that we could provide a separate palette for them. I believe this is achieved via the `DesignType` type as seen in this MAPI change: https://github.com/guardian/mobile-apps-api/pull/1885 However, from what I can tell there was no plan to introduce new article designs on AR and DCR? If that's the case then I don't _believe_ we also need to make changes to the `Design` type that's part of `Format`? I've therefore removed the `NewsletterDesign` from this type and the corresponding predicate and test. Let me know if you think this is incorrect.

## `DesignType` vs `Design`

<dl>
<dt>DesignType</dt>
<dd>Garnett-era type used to describe article designs. This is still in use in MAPI for fronts etc., and Frontend for Twirl templates, fronts etc. It is not, AFAIK, used in AR or DCR.</dd>
<dt>Design</dt>
<dd>Rendering-era type that makes up part of the <code>Format</code> type. The <code>Format</code> type as a whole provides a full description of article designs. It is used in AR and DCR.</dd>
</dl>

These two types rather confusingly have similar names and appear to be made up of very similar sub-types like "analysis", "review", "comment" etc. This is because `Format` as a whole, including `Design`, was partly evolved from `DesignType`, and therefore shares many similarities. However, `Format` is the more modern representation and more accurately describes our articles. `Format`, and its `Design`, `Display` and `Theme` sub-types, is the one used in our modern rendering platforms: AR and DCR. `DesignType` is still used in our older article representations in Frontend and MAPI, and I believe also appears for fronts.

## Changes

- Remove `NewsletterSignup` from `DesignType`
- Remove `NewsletterDesign` from `Design`
- Add parsing predicate for `NewsletterSignupDesign`
- Update tests to capture changes
