### PR TITLE
Prioritise live/deadblog over match report

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -106,11 +106,11 @@ object CapiModelEnrichment {
         tagExistsWithId("tone/interview") -> InterviewDesign,
         tagExistsWithId("tone/features") -> FeatureDesign,
         tagExistsWithId("tone/recipes") -> RecipeDesign,
-        tagExistsWithId("tone/matchreports") -> MatchReportDesign,
         tagExistsWithId("tone/editorials") -> EditorialDesign,
         tagExistsWithId("tone/quizzes") -> QuizDesign,
         isLiveBlog -> LiveBlogDesign,
         isDeadBlog -> DeadBlogDesign,
+        tagExistsWithId("tone/matchreports") -> MatchReportDesign,
       )
 
       val result = getFromPredicate(content, predicates)


### PR DESCRIPTION
## What does this change?

Prioritises 'Liveblog' and 'Deadblog' design over 'MatchReport' - There are some old liveblogs (e.g https://www.theguardian.com/football/live/2015/mar/19/dynamo-kyiv-v-everton-europa-league-live) which have both tags and they should be treated as live/deadblogs rather than match reports.

I've changed this for format.design, but not for designType, as I'm guessing designType is used for something else, likely not affected by the above issue?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

This should be covered by existing tests.

To my knowledge it's not possible with the current test framework to mock multiple tags and therefor check that 'predicates' is working as expected - perhaps this should be an enhancement in a future PR?

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Have we considered potential risks?

From what I can tell moving MatchReport design down the predicates _shouldn't_ have any unintended effects, but this could be incorrect.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

