### PR TITLE
De-prioritise NewsletterSignupDesign

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -92,9 +92,9 @@ object CapiModelEnrichment {
       // Note: only the first matching predicate will be picked.
       // Modifying the order of predicates could create unintended problems:
       val predicates: List[(ContentFilter, Design)] = List(
-        tagExistsWithId("info/newsletter-sign-up") -> NewsletterSignupDesign,
         isFullPageInteractive -> FullPageInteractiveDesign,
         isInteractive -> InteractiveDesign,
+        tagExistsWithId("info/newsletter-sign-up") -> NewsletterSignupDesign,
         tagExistsWithId("artanddesign/series/guardian-print-shop") -> PrintShopDesign,
         tagExistsWithId("type/gallery") -> GalleryDesign,
         tagExistsWithId("type/audio") -> AudioDesign,


### PR DESCRIPTION
## What does this change?

Interactives should be respected over 'NewsletterSignupDesign' as there are interactives with the tag that currently should be considered an `Interactive` instead of a NewsLetterSignupDesign (this may change in the future)

