### PR TITLE
add query-fields to queries

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -266,6 +266,7 @@ trait FilterSectionParameters[Owner <: Parameters[Owner]] extends Parameters[Own
 
 trait FilterSearchParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
   def q = StringParameter("q")
+  def queryFields = StringParameter("query-fields")
 }
 
 trait AtomsParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>

--- a/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
@@ -14,8 +14,8 @@ class ContentApiQueryTest extends FlatSpec with Matchers  {
   }
 
   "SearchQuery" should "also be excellent" in {
-    SearchQuery().tag("profile/robert-berry").showElements("all").contentType("article").getUrl("") shouldEqual
-      "/search?tag=profile%2Frobert-berry&show-elements=all&type=article"
+    SearchQuery().tag("profile/robert-berry").showElements("all").contentType("article").queryFields("body").getUrl("") shouldEqual
+      "/search?tag=profile%2Frobert-berry&show-elements=all&type=article&query-fields=body"
   }
 
   "SearchQuery" should "not be perturbed when asked to show alias paths" in {


### PR DESCRIPTION
## What does this change?
Adds the `query-fields` to the Queries

## How to Test:
A snapshot version `18.0.2-SNAPSHOT` was published and tested in the relevant project https://github.com/guardian/top-mentions-aggregator/pull/3
