### PR TITLE
Remove superfluous/confusing `version.sbt` files

### DIFF
--- a/client-default/version.sbt
+++ b/client-default/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "17.24.0-SNAPSHOT"

--- a/client/version.sbt
+++ b/client/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "17.24.0-SNAPSHOT"


### PR DESCRIPTION
The current releases of `content-api-client` on Maven Central are v18.0.2 :

https://repo1.maven.org/maven2/com/gu/content-api-client_2.13/18.0.2/

...and we have a top-level `version.sbt` file that agrees (pointing at the next snapshot version, `18.0.3-SNAPSHOT`):

https://github.com/guardian/content-api-scala-client/blob/1a123d96af9dc2476c69589d2859f373d967dcaa/version.sbt#L1

**BUT** there are also these `version.sbt` files in subfolders in the current project that override that version to `17.24.0-SNAPSHOT` ??

https://github.com/guardian/content-api-scala-client/blob/1a123d96af9dc2476c69589d2859f373d967dcaa/client-default/version.sbt#L1
https://github.com/guardian/content-api-scala-client/blob/1a123d96af9dc2476c69589d2859f373d967dcaa/client/version.sbt#L1


If you check out `main` on this repo at the moment and run `sbt ++publishLocal`, the version of artifacts that are published will be `17.24.0-SNAPSHOT`, which is not helpful 😢  If you are trying to test out your locally-built client with other projects that use the CAPI client, the other projects may end up selecting published versions of the CAPI client with more-recent version numbers, rather than the locally-built version you want to test.


https://user-images.githubusercontent.com/52038/172589601-42026114-8545-4471-91f6-2356bf24658c.mov



I can't see why these sub-versions need to exist, and think it would be better if they were removed so there's no ambiguity to the version?!

I realise that there is version differential with https://github.com/guardian/content-api-models, which is fine, it's a different repo and I think I understand that, but not why these old version numbers are hanging around in https://github.com/guardian/content-api-scala-client ?

## How to test

Once this merged, I'll perform a release a double-check that the released version numbers make sense.

cc @ioannakok 