### PR TITLE
proposal: Switch from manual `CHANGELOG.md` to GitHub Releases

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Latest information in GitHub Releases
+
+Check out **https://github.com/guardian/content-api-scala-client/releases**
+for info on all releases from v19.0.0 onwards. For historical reference
+purposes, information on prior releases is included below.
+
+### Releases prior to v19.0.0...
+
 ## 18.0.1
 
 ### Bug fixes

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,7 +17,11 @@ As part of the release process, you will be asked to specify the version of this
 
 Debugging note: if you get an error that prevents deploy and says the commit could not be properly 'signed' by your gpg key, it is worth adding the following line to your `~/.zshrc`, bash profile, or similar: `export GPG_TTY=$(tty)` and open a new terminal window. This allows your current terminal session to access and use your GPG keys if it cannot by default.
 
-Once this version has been released, update `CHANGELOG.md` with a description of the change.
+Once the new version has been released, create a GitHub Release
+([guide](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)) 
+describing the change (the `Generate release notes` button can give you a good start!):
+
+https://github.com/guardian/content-api-scala-client/releases/new
 
 #### Non-production releases:
 If you intend to publish a beta or snapshot build (e.g. from a WIP code branch) for testing the library in another application prior to releasing your changes to production - which can be useful when testing the effects of upgrading dependencies etc - you should also send the appropriate value in a parameter:


### PR DESCRIPTION
A `CHANGELOG.md` file is nice & compact, but requires manual formatting and doesn't integrate with GitHub's UI. [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) has some advantages:

* gives handy automation for writing release notes!
* can be interrogated through the GitHub API
* has a standard url: **https://github.com/guardian/content-api-scala-client/releases**
* has a standard place in the GitHub UI, eg ![image](https://user-images.githubusercontent.com/52038/176870100-20568a71-859c-4373-86ae-2ea8e4c9fb0b.png)

![image](https://user-images.githubusercontent.com/52038/176868659-edb2b063-0763-48ca-b8bc-183dc64a780f.png)

This is just a suggestion - happy if the CAPI team would prefer to continue with the changelog approach!

