### PR TITLE
Fix `facia-tool` upgrade: tweak `SearchQueryBase`

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -51,7 +51,7 @@ abstract class PaginatedApiQuery[Response <: ThriftStruct, Element](
 }
 
 trait SearchQueryBase[Self <: SearchQueryBase[Self]]
-  extends PaginatedApiQuery[SearchResponse, Content]
+  extends ContentApiQuery[SearchResponse]
      with ShowParameters[Self]
      with ShowReferencesParameters[Self]
      with OrderByParameter[Self]
@@ -85,7 +85,7 @@ case class ItemQuery(id: String, parameterHolder: Map[String, Parameter] = Map.e
 }
 
 case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-  extends SearchQueryBase[SearchQuery] {
+  extends PaginatedApiQuery[SearchResponse, Content] with SearchQueryBase[SearchQuery] {
 
   def setPaginationConsistentWith(response: SearchResponse): PaginatedApiQuery[SearchResponse, Content] =
     pageSize.setIfUndefined(response.pageSize).orderBy.setIfUndefined(response.orderBy)


### PR DESCRIPTION
## What's the problem?

`facia-tool` uses the CAPI client, and in particular has a custom [**`CapiQueryGenerator`**](https://github.com/guardian/facia-tool/blob/38790184f12300c6fb1d4f30b07da62452b32606/app/services/Capi.scala#L231-L237) query class that extends CAPI client's `SearchQueryBase` class. The changes in PR https://github.com/guardian/content-api-scala-client/pull/359 mean that all classes extending `SearchQueryBase` are also extending `PaginatedApiQuery`.

Consequently `CapiQueryGenerator` **unexpectedly needed to implement [two obscure methods](https://github.com/guardian/content-api-scala-client/blob/a7895752d72a8688f7e85aaeca78b664ad9e8b79/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala#L42-L50)** from `PaginatedApiQuery` (`setPaginationConsistentWith` & `followingQueryGivenFull`) when upgrading to CAPI client v19 - otherwise [compilation fails in `facia-tool`](https://teamcity.gutools.co.uk/viewLog.html?buildId=786495&buildTypeId=EditorialTools_FaciaTool&tab=buildLog&_focus=1334).

It's not fair to block upgrades by asking end users to implement these unfamiliar methods - especially if they aren't using the auto-pagination that needs them. When I was working on https://github.com/guardian/content-api-scala-client/pull/359 I wasn't really aware of how many classes would be extending `SearchQueryBase` or why! 

## What's the fix?

Rather than implementing those obscure methods in `facia-tool`'s `CapiQueryGenerator` class, I'm making the smallest possible change to the CAPI client so that no change to `facia-tool` is necessary - removing `PaginatedApiQuery` from `SearchQueryBase` and placing it directly on the concrete `SearchQuery` class.

#### Before

```mermaid
classDiagram
    PaginatedApiQuery <|-- SearchQueryBase
    SearchQueryBase <|-- SearchQuery
    SearchQueryBase <|-- CapiQueryGenerator
```

#### After

```mermaid
classDiagram
    PaginatedApiQuery <|-- SearchQuery
    SearchQueryBase <|-- SearchQuery
    SearchQueryBase <|-- CapiQueryGenerator
```

I've released a beta of this change (at commit 89a4ffd515dfc0653ca2b5b5272e7b6a3295af97) as `19.0.1-beta.0`, and you can see that [using this fixed the compilation error](https://github.com/guardian/facia-tool/pull/1448/commits/b4dabb64ef7f09e47e74460119042284fdc4be11) when upgrading `facia-tool`.


An alternative approach might be to support auto-pagination much more extensively, ie allow it everywhere that a query implements `PaginationParameters`, but there's a fair bit of change involved in getting there, so I'm leaving it for now.

## What is `facia-tool`'s `CapiQueryGenerator` for?

`CapiQueryGenerator` is used for Kindle & Editions support - it queries the `/content/print-sent` endpoint (introduced in https://github.com/guardian/content-api/pull/1131), which can access _preview_ as well as live content, and filters to just content that is eligible for Kindle / Editions - that is, content which has all [the metadata that indicates where it will go in the print newspaper](https://github.com/guardian/content-api/blob/70bdc66a41c8b196bfc9a02fc4bdbbb65b0619de/porter/src/main/scala/com.gu.contentapi.porter/integration/flexible/FlexibleTransformer.scala#L275-L284) - a page number, a print date, etc. The endpoint does not support `prev` or `next` endpoints like standard `/search` would, so far as I know?

Thanks to @Fweddi for lots of context about the endpoint! See [this chat in `P&E/Editorial Tools/Fronts`](https://chat.google.com/room/AAAAXBA-uZk/9vfGLIqqoQ8).

