### PR TITLE
Render obituary letters as letters

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -43,7 +43,9 @@ object CapiModelEnrichment {
   val publishedBeforeInteractiveImmersiveSwitchover: ContentFilter = content => content.fields.flatMap(_.creationDate).exists(date => ZonedDateTime.parse(date.iso8601).isBefore(immersiveInteractiveSwitchoverDate))
   
   val isLegacyImmersiveInteractive: ContentFilter = content => isInteractive(content) && isImmersive(content) && publishedBeforeInteractiveImmersiveSwitchover(content)
-  
+
+  val isObituary: ContentFilter = content => (tagExistsWithId("tone/obituaries")(content) && !tagExistsWithId("tone/letters")(content))
+
   val isFullPageInteractive: ContentFilter = content => isInteractive(content) && (displayHintExistsWithName("fullPageInteractive")(content) || isLegacyImmersiveInteractive(content))
   implicit class RichCapiDateTime(val cdt: CapiDateTime) extends AnyVal {
     def toOffsetDateTime: OffsetDateTime = OffsetDateTime.parse(cdt.iso8601)
@@ -100,7 +102,7 @@ object CapiModelEnrichment {
         tagExistsWithId("type/audio") -> AudioDesign,
         tagExistsWithId("type/video") -> VideoDesign,
         isReview -> ReviewDesign,
-        tagExistsWithId("tone/obituaries") -> ObituaryDesign,
+        isObituary -> ObituaryDesign,
         tagExistsWithId("tone/analysis") -> AnalysisDesign,
         tagExistsWithId("tone/comment") -> CommentDesign,
         tagExistsWithId("tone/letters") -> LetterDesign,


### PR DESCRIPTION
Co-Authored-By: Ashleigh Carr <ashcorr20@gmail.com>
Co-Authored-By: Ioanna Kokkini <ioannakok@users.noreply.github.com>

## What does this change?
This change renders obituary letters as letters and resolves issue https://github.com/guardian/dotcom-rendering/issues/5628.



<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Have we considered potential risks?

The following filter function was chosen to prevent possible side effects of changing the order of the predicates list.
```val isObituary: ContentFilter = content => (tagExistsWithId("tone/obituaries")(content) && !tagExistsWithId("tone/letters")(content))```

However we could not find any articles that shared the tags in the hierarchy between obituaries and letters and simply changing the order may be a better more implicit implementation.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="272" alt="image" src="https://user-images.githubusercontent.com/110032454/184637314-50d1ed27-9f93-4129-ae81-29b6ff995ea7.png">

<img width="272" alt="image" src="https://user-images.githubusercontent.com/110032454/184637343-c3a0c5bb-ab27-4c28-89ee-18ad43a196dc.png">



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


