### PR TITLE
Adding a new ExplainerDesign to Format

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -102,6 +102,7 @@ object CapiModelEnrichment {
         isReview -> ReviewDesign,
         tagExistsWithId("tone/obituaries") -> ObituaryDesign,
         tagExistsWithId("tone/analysis") -> AnalysisDesign,
+        tagExistsWithId("tone/explainer") -> ExplainerDesign,
         tagExistsWithId("tone/comment") -> CommentDesign,
         tagExistsWithId("tone/letters") -> LetterDesign,
         isPhotoEssay -> PhotoEssayDesign,

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
@@ -8,6 +8,7 @@ case object AudioDesign extends Design
 case object VideoDesign extends Design
 case object ReviewDesign extends Design
 case object AnalysisDesign extends Design
+case object ExplainerDesign extends Design
 case object CommentDesign extends Design
 case object LetterDesign extends Design
 case object FeatureDesign extends Design

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -268,6 +268,13 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.design shouldEqual AnalysisDesign
   }
 
+  it should "have a design of 'ExplainerDesign' when tag tone/explainer is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/explainer"
+
+    f.content.design shouldEqual ExplainerDesign
+  }
+
   it should "have a design of 'CommentDesign' when tag tone/comment is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "tone/comment"


### PR DESCRIPTION
## What does this change?

Creating ExplainerDesign to use for articles with the explainer tone tag. This is part of work for the Editorial Design team detailed here: https://docs.google.com/document/d/1MqSldxfgR86kOJaXTFNaBs5LzPzSa7jC4D4YwqqMFwg/edit#
