### PR TITLE
Add `SpecialReportAltTheme` to `Format`

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -151,23 +151,22 @@ object CapiModelEnrichment {
         "0d18e8413ab7cdf377e1202d24452e63"
       )
 
-      val specialReportAltTags: Set[String] = Set(
-
+      val hashedSpecialReportAltTags: Set[String] = Set(
+        "2943c2fcbfa65e6505ca00eb805350bf"
       )
 
       val salt = "a-public-salt3W#ywHav!p+?r+W2$E6="
 
       def isPillar(pillar: String): ContentFilter = content => content.pillarName.contains(pillar)
 
-      def hashedTagIds = content.tags.map { tag =>
+      def hashedTagIds(content: Content) = content.tags.map { tag =>
         DigestUtils.md5Hex(salt + tag.id)
       }
 
       val isSpecialReport: ContentFilter = content =>
-        content.tags.exists(t => specialReportTags(t.id)) || hashedTagIds.exists(hashedSpecialReportTags.apply)
+        content.tags.exists(t => specialReportTags(t.id)) || hashedTagIds(content).exists(hashedSpecialReportTags.apply)
 
-      val isSpecialReportAlt: ContentFilter = content =>
-        content.tags.exists(t => specialReportAltTags(t.id))
+      val isSpecialReportAlt: ContentFilter = content => hashedTagIds(content).exists(hashedSpecialReportAltTags.apply)
 
       val isOpinion: ContentFilter = content =>
         (tagExistsWithId("tone/comment")(content) && isPillar("News")(content)) ||

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -151,6 +151,10 @@ object CapiModelEnrichment {
         "0d18e8413ab7cdf377e1202d24452e63"
       )
 
+      val specialReportAltTags: Set[String] = Set(
+
+      )
+
       val salt = "a-public-salt3W#ywHav!p+?r+W2$E6="
 
       def isPillar(pillar: String): ContentFilter = content => content.pillarName.contains(pillar)
@@ -162,6 +166,9 @@ object CapiModelEnrichment {
       val isSpecialReport: ContentFilter = content =>
         content.tags.exists(t => specialReportTags(t.id)) || hashedTagIds.exists(hashedSpecialReportTags.apply)
 
+      val isSpecialReportAlt: ContentFilter = content =>
+        content.tags.exists(t => specialReportAltTags(t.id))
+
       val isOpinion: ContentFilter = content =>
         (tagExistsWithId("tone/comment")(content) && isPillar("News")(content)) ||
           (tagExistsWithId("tone/letters")(content) && isPillar("News")(content)) ||
@@ -170,6 +177,7 @@ object CapiModelEnrichment {
 
       val predicates: List[(ContentFilter, Theme)] = List(
         isSpecialReport -> SpecialReportTheme,
+        isSpecialReportAlt -> SpecialReportAltTheme,
         tagExistsWithId("tone/advertisement-features") -> Labs,
         isOpinion -> OpinionPillar,
         isPillar("Sport") -> SportPillar,

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Theme.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Theme.scala
@@ -11,4 +11,5 @@ case object SportPillar extends Pillar
 case object CulturePillar extends Pillar
 case object LifestylePillar extends Pillar
 case object SpecialReportTheme extends Special
+case object SpecialReportAltTheme extends Special
 case object Labs extends Special


### PR DESCRIPTION
## What does this change?

* Adds `SpecialReportAltTheme` to `Format` 
* Adds a hashed special report alt tag for an upcoming special report

Part of the work for the new `SpecialReportAlt` theme: https://docs.google.com/document/d/1YnWmfEa1nQKEGgJbPgs9cp9VaMBOBILqGNRqqsZ0Jys/edit#

This PR is the 1st in this series:
1. `content-api-scala-client`: Adds SpecialReportAltTheme and SpecialReportAlt hashed tag to content-api-scala-client: https://github.com/guardian/content-api-scala-client/pull/371 (**current**)
2. `facia-scala-client`: Adds SpecialReportAlt to CardStyle: https://github.com/guardian/facia-scala-client/pull/280
3. `frontend`: Consumes the new SpecialReportAltTheme and adds SpecialReportAlt card styles for fronts rendered by frontend: https://github.com/guardian/frontend/pull/25602

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
* Tested locally using the SNAPSHOT version in `facia-scala-client` and `frontend`
* Tested locally with a unit test that when a specific tag is present the theme equals `SpecialReportAltTheme`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

