### PR TITLE
Update capi model version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.3.1-SNAPSHOT" // this needs the version of https://github.com/guardian/content-api-models/pull/216
+  val capiModelsVersion = "17.3.2-beta.0" // this needs the version of https://github.com/guardian/content-api-models/pull/216
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.3.2-beta.0" // this needs the version of https://github.com/guardian/content-api-models/pull/216
+  val capiModelsVersion = "17.4.0"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.3.0"
+  val capiModelsVersion = "17.3.1-SNAPSHOT" // this needs the version of https://github.com/guardian/content-api-models/pull/216
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"


### PR DESCRIPTION
## What does this change?
The purpose of this PR is to update the version of `content-api-models-scala`. The new version contains a new element type callout. 

## Describe your changes

This PR is the seventh(final) step of the work for adding a new `callout` element in CAPI pipeline, as explained below:

1. flexible-model: Add callout element to flexible content thrift model https://github.com/guardian/flexible-model/pull/52
2. flexible-content: Consume callout version of flexible model https://github.com/guardian/flexible-content/pull/4233 
3. content-api/elasticsearch: Add callout element type to elasticsearch https://github.com/guardian/content-api/pull/2708
4. content-api/porter: Add callout element type to porter https://github.com/guardian/content-api/pull/2704
5. content-api-models: Add callout to capi thrift model https://github.com/guardian/content-api-models/pull/216
6. content-api/concierge: update content-api-models version to add callout in concierge https://github.com/guardian/content-api/pull/2705
7. content-api-scala-client: Update capi model version **(current PR)**

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## TODO:
The current used version is the snapshot version. After the new `content-api-models-scala` version is published, this PR needs to get updated.

## How to test

This has been tested locally
