### PR TITLE
Bump content-api-models version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.5.0-beta.0"
+  val capiModelsVersion = "17.5.1"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.4.0"
+  val capiModelsVersion = "17.5.0-beta.0"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "19.2.0-beta.1"
+ThisBuild / version := "19.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "19.1.1-SNAPSHOT"
+ThisBuild / version := "19.2.0-beta.1"


### PR DESCRIPTION
Due to https://github.com/guardian/content-api-models/pull/218 

## What does this change?

Pulling in an updated version of content-api-models from the above linked PR. 
This adds `optional bool isMandatory` fields to the thrift models of

  * AudioElementFields
  * CommentElementFields
  * ContentAtomElementFields
  * TweetElementFields
  * VideoElementFields

## How to test

Release a [beta build](https://repo1.maven.org/maven2/com/gu/content-api-client_2.13/19.2.0-beta.0/) and test in a consumer [application](https://github.com/guardian/apple-news/tree/jp/allow-compatible-interactives)

## How can we measure success?

Does it do all the right things? Success!

## Have we considered potential risks?

Once released to the World (as a non-beta) it's up to consumers to update it when they choose. We'll have tested it in at least one application before then.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] Not applicable

