### PR TITLE
update capi model version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.4.0"
+  val capiModelsVersion = "17.4.2"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR aims to update the CAPI model version to the latest in order to successfully read the new `showTableOfContents` field.

As a result of the release of https://github.com/guardian/content-api-models/releases/tag/v17.4.2. We can now update this version to be consumed downstream by platforms

 ## Steps taken
1. content-api/elasticsearch: Add Table of Contents type to elasticsearch https://github.com/guardian/content-api/pull/2718
2. content-api/porter: Add Table of Contents field to porter https://github.com/guardian/content-api/pull/2719
3. content-api-models: Add Table of Contents to capi thrift model https://github.com/guardian/content-api-models/pull/217
4. content-api/concierge: update content-api-models version to add Table of Contents in concierge - https://github.com/guardian/content-api/pull/2720 
5. content-api-scala-client: Update capi model version - **Current PR**
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
