### PR TITLE
Feat: add the new TimelineDesign and ProfileDesign to Format

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -116,6 +116,8 @@ object CapiModelEnrichment {
         isLiveBlog -> LiveBlogDesign,
         isDeadBlog -> DeadBlogDesign,
         tagExistsWithId("tone/matchreports") -> MatchReportDesign,
+        tagExistsWithId("tone/timelines") -> TimelineDesign,
+        tagExistsWithId("tone/profiles") -> ProfileDesign,
       )
 
       val result = getFromPredicate(content, predicates)

--- a/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/DesignType.scala
@@ -19,3 +19,5 @@ case object GuardianLabs extends DesignType
 case object Quiz extends DesignType
 case object AdvertisementFeature extends DesignType
 case object Newsletter extends DesignType
+case object Timeline extends DesignType
+case object Profile extends DesignType

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
@@ -25,3 +25,5 @@ case object PhotoEssayDesign extends Design
 case object PrintShopDesign extends Design
 case object ObituaryDesign extends Design
 case object NewsletterSignupDesign extends Design
+case object TimelineDesign extends Design
+case object ProfileDesign extends Design

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -169,8 +169,7 @@ class CapiModelEnrichmentDesignTypeTest extends FlatSpec with MockitoSugar with 
     when(f.tag.id) thenReturn "tone/newsletter-tone"
 
     f.content.designType shouldEqual Newsletter
-  }  
-
+  }
 }
 
 class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matchers {
@@ -464,7 +463,21 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     when(f.tag.id) thenReturn "info/newsletter-sign-up"
 
     f.content.design shouldEqual NewsletterSignupDesign
-  }  
+  }
+
+  it should "have a design of 'TimelineDesign' when tag tone/timelines is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/timelines"
+
+    f.content.design shouldEqual TimelineDesign
+  }
+
+  it should "have a design of 'ProfileDesign' when tag tone/profiles is present" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "tone/profiles"
+
+    f.content.design shouldEqual ProfileDesign
+  }
 
   behavior of "Format.theme"
 


### PR DESCRIPTION
## What does this change?
This PR extends Format to include TimelineDesign and ProfileDesign. These will be used for articles with the timelines and profiles tone tag respectively. This is part of work for the Editorial Design team.