### PR TITLE
Remove status message from expected results

### DIFF
--- a/client-default/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/client-default/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -41,7 +41,7 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ScalaFutures
   it should "return errors as a broken promise" in {
     val query = ItemQuery("something-that-does-not-exist")
     val errorTest = api.getResponse(query) recover { case error =>
-      error should be (ContentApiError(404, "", Some(ErrorResponse("error", "The requested resource could not be found."))))
+      error should matchPattern { case ContentApiError(404, _, Some(ErrorResponse("error", "The requested resource could not be found."))) => }
     }
     errorTest.futureValue
   }
@@ -49,7 +49,7 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ScalaFutures
   it should "handle error responses" in {
     val query = SearchQuery().pageSize(500)
     val errorTest = api.getResponse(query) recover { case error =>
-      error should be (ContentApiError(400, "", Some(ErrorResponse("error", "page-size must be an integer between 0 and 200"))))
+      error should matchPattern { case ContentApiError(400, _, Some(ErrorResponse("error", "page-size must be an integer between 0 and 200"))) => }
     }
     errorTest.futureValue
   }

--- a/client-default/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/client-default/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -41,7 +41,7 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ScalaFutures
   it should "return errors as a broken promise" in {
     val query = ItemQuery("something-that-does-not-exist")
     val errorTest = api.getResponse(query) recover { case error =>
-      error should be (ContentApiError(404, "Not Found", Some(ErrorResponse("error", "The requested resource could not be found."))))
+      error should be (ContentApiError(404, "", Some(ErrorResponse("error", "The requested resource could not be found."))))
     }
     errorTest.futureValue
   }
@@ -49,7 +49,7 @@ class GuardianContentClientTest extends FlatSpec with Matchers with ScalaFutures
   it should "handle error responses" in {
     val query = SearchQuery().pageSize(500)
     val errorTest = api.getResponse(query) recover { case error =>
-      error should be (ContentApiError(400, "Bad Request", Some(ErrorResponse("error", "page-size must be an integer between 0 and 200"))))
+      error should be (ContentApiError(400, "", Some(ErrorResponse("error", "page-size must be an integer between 0 and 200"))))
     }
     errorTest.futureValue
   }


### PR DESCRIPTION
## What does this change?

Due to the new Kong infrastructure introduced here [Kong](https://github.com/guardian/content-api/pull/2728) CAPI now returns HTTP/2 responses in which the error status message no longer exists, which broke the following two tests:

<img width="444" alt="Screenshot 2023-01-18 at 15 22 58" src="https://user-images.githubusercontent.com/74187452/213211696-de244e66-76f0-4d62-9f4a-819faab58035.png">

This change removes the status message from the expected CAPI responses to get the tests to pass again.

## How to test

Should build successfully in TeamCity

