### PR TITLE
Revert "Bump content-api-models version"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.5.1"
+  val capiModelsVersion = "17.4.2"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "19.2.0-SNAPSHOT"
+ThisBuild / version := "19.1.3-SNAPSHOT"


### PR DESCRIPTION
Reverts guardian/content-api-scala-client#374

Tests are failing on `main` so let's start investigating by undoing this merge.