### PR TITLE
updated special report alt tag hash

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -154,7 +154,7 @@ object CapiModelEnrichment {
       )
 
       val hashedSpecialReportAltTags: Set[String] = Set(
-        "2943c2fcbfa65e6505ca00eb805350bf"
+        "beb7e395cdb815dff6af13f7eda9d1e4"
       )
 
       val salt = "a-public-salt3W#ywHav!p+?r+W2$E6="


### PR DESCRIPTION
Co-authored-by: Ioanna Kokkini <ioanna.kokkini@guardian.co.uk>

## What does this change?

Adds a hashed special report alt tag for an upcoming special report

## How to test

Tested locally with a unit test that when a specific tag is present the theme equals SpecialReportAltTheme

