### PR TITLE
Bump CAPI models to 17.5.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.5.1"
+  val capiModelsVersion = "17.5.2"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR pulls in content-api-models 17.5.2 (https://github.com/guardian/content-api-models/pull/220), which supports the new optional field of `pocketCastsUrls` in tag.

This PR is required to allow MAPI to consume the new data field through the content-api-scala-client module.

