### PR TITLE
Bump CAPI model to include the optional overrides fields for Callouts

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.5.2"
+  val capiModelsVersion = "17.6.2"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "19.2.4-SNAPSHOT"
+ThisBuild / version := "19.3.0-SNAPSHOT"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This bumps the version of CAPI so we include the following new optional fields for the Callout elements

- overridePrompt
- overrideTitle
- overrideDescription


This PR is the seventh step of the work for updating the callout element in CAPI pipeline:
1. flexible-model: https://github.com/guardian/flexible-model/pull/55
2. flexible-content: https://github.com/guardian/flexible-content/pull/4233
3. content-api/elasticsearch: https://github.com/guardian/content-api/pull/2754
4. content-api/porter: https://github.com/guardian/content-api/pull/2755
5. content-api-models: https://github.com/guardian/content-api-models/pull/221
6. content-api/concierge: https://github.com/guardian/content-api/pull/2756
7. **content-api-scala-client**
