### PR TITLE
Add showChannels param

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -283,6 +283,7 @@ trait ShowParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { thi
   def showSection = BoolParameter("show-section")
   def showStats = BoolParameter("show-stats")
   def showAliasPaths = BoolParameter("show-alias-paths")
+  def showChannels = StringParameter("show-channels")
 }
 
 trait ShowReferencesParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>

--- a/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
@@ -28,6 +28,11 @@ class ContentApiQueryTest extends FlatSpec with Matchers  {
       "/search?paths=path%2Fone%2Cpath%2Ftwo"
   }
 
+  "SearchQuery" should "provide channels when requested with an internal tier key" in {
+    SearchQuery().paths("path/one,path/two").showChannels("all").getUrl("") shouldEqual
+      "/search?paths=path%2Fone%2Cpath%2Ftwo&show-channels=all"
+  }
+
   "SectionsQuery" should "be beautiful" in {
     SectionsQuery().getUrl("") shouldEqual "/sections"
   }


### PR DESCRIPTION
## What does this change?

We're adding the `showChannels` parameter.

## How to test

Unit tests ensure that the parameter is correctly mapped to the backend query.

## How can we measure success?

Consumers can request (API key tier permitting) visibility of channel data.

## Have we considered potential risks?

This is very low risk, we're just shadowing a feature that is already understood in CAPI.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A (there is no UI here)
