### PR TITLE
Bump version of content-api-models

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.6.2"
+  val capiModelsVersion = "17.7.4-SNAPSHOT"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "19.3.2-SNAPSHOT"
+ThisBuild / version := "19.4.2-SNAPSHOT"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Pulls in the latest version of content-api-models. The change to content api models includes the category field on assets.

## Other related PRs
- content-api-models: https://github.com/guardian/content-api-models/pull/225
- **content-api-scala-client (this one)**
- frontend: https://github.com/guardian/frontend/pull/26316
- frontend: https://github.com/guardian/frontend/pull/26317
- DCR: https://github.com/guardian/dotcom-rendering/pull/8277
