### PR TITLE
To apply latest version of capiModelsVersion.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.6.2"
+  val capiModelsVersion = "17.6.3"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"


### PR DESCRIPTION
## What does this change?

This is to update `content-api-scala-client` to avoid error between latest and old version of `content-api-models` in the repos (example apple-news) that are using both libraries.

Related to the work of Scala Steward integration in apple-news code. We are encountering error `NoSuchMethodError` at the moment , details are in ongoing PR https://github.com/guardian/apple-news/pull/249, which is happening after upgrading latest versions of both `content-scala-client` and `content-api-models`. This suggests that scala-client is not updated with latest models hence applying the change to release updated version of scala-client. 
(Guided by Roberto Tyley)

## How to test

To test in AN code of we able to resolve the error.

## How can we measure success?

Error should be resolved and tests should pass in apple-news code on using latest versions of the api's.