### PR TITLE
Bump CAPI model version to support Cartoon element

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.7.0-beta.0"
+  val capiModelsVersion = "17.7.0-beta.1"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.6.3"
+  val capiModelsVersion = "17.7.0-beta.0"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.7.0-beta.1"
+  val capiModelsVersion = "17.7.0"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"


### PR DESCRIPTION
## What does this change?
Bump content-api-model library to latest version to bring in Cartoon element.
