### PR TITLE
Backfill query parameter test to document correct encoding of pipe char in parameters

### DIFF
--- a/client/src/test/scala/com/gu/contentapi/client/utils/QueryStringParamsTest.scala
+++ b/client/src/test/scala/com/gu/contentapi/client/utils/QueryStringParamsTest.scala
@@ -1,0 +1,18 @@
+package com.gu.contentapi.client.utils
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class QueryStringParamsTest extends FlatSpec with Matchers {
+
+  "QueryStringParams" should "correctly encode GET query string parameters" in {
+
+    val questionableParams = Seq(
+      ("foo", "bar"),
+      ("withPlus", "1+2=3"),
+      ("withPipe", "(tone/analytics|tone/comment)")
+    )
+
+    QueryStringParams.apply(questionableParams) should be("?foo=bar&withPlus=1%2B2%3D3&withPipe=%28tone%2Fanalytics%7Ctone%2Fcomment%29")
+  }
+
+}


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Test to eliminate query parameter encoder from enquires.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Test only. Should be low risk.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
