### PR TITLE
Exclude Picture content type from Print Shop design

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -41,6 +41,8 @@ object CapiModelEnrichment {
 
   val isGallery: ContentFilter = tagExistsWithId("type/gallery")
 
+  val isPrintShop: ContentFilter = content => !isPictureContent(content) && tagExistsWithId("artanddesign/series/guardian-print-shop")(content)
+
   // The date used here is arbitrary and will be moved nearer to the present when the new template feature is ready to be used in production
   val immersiveInteractiveSwitchoverDate = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
   
@@ -101,7 +103,7 @@ object CapiModelEnrichment {
         isFullPageInteractive -> FullPageInteractiveDesign,
         isInteractive -> InteractiveDesign,
         tagExistsWithId("info/newsletter-sign-up") -> NewsletterSignupDesign,
-        tagExistsWithId("artanddesign/series/guardian-print-shop") -> PrintShopDesign,
+        isPrintShop -> PrintShopDesign,
         isGallery -> GalleryDesign,
         isPictureContent -> PictureDesign,
         tagExistsWithId("type/audio") -> AudioDesign,

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -218,6 +218,14 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.design shouldEqual PrintShopDesign
   }
 
+  it should "have a design of PictureDesign when tag artanddesign/series/guardian-print-shop is present on Picture content" in {
+    val f = fixture
+    when(f.tag.id) thenReturn "artanddesign/series/guardian-print-shop"
+    when(f.content.`type`) thenReturn ContentType.Picture
+
+    f.content.design shouldEqual PictureDesign
+  }
+
   it should "have a design of 'AudioDesign' when tag type/audio is present" in {
     val f = fixture
     when(f.tag.id) thenReturn "type/audio"


### PR DESCRIPTION
## What does this change?
The `artanddesign/series/guardian-print-shop` is applying some unforeseen styling to cartoons in the Picture content type. As such, we would like to exclude Picture content from the `PrintShopDesign` and instead apply `PictureDesign` which is the correct styling for this content type.
