### PR TITLE
Add keyTakeaways as a displayHint

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -256,10 +256,13 @@ object CapiModelEnrichment {
 
       val isNumberedList: ContentFilter = displayHintExistsWithName("numberedList")
 
+      val isKeyTakeaways: ContentFilter = displayHintExistsWithName("keyTakeaways")
+
       val predicates: List[(ContentFilter, Display)] = List(
         isFullPageInteractive -> StandardDisplay,
         isImmersiveDisplay -> ImmersiveDisplay,
         isNumberedList -> NumberedListDisplay,
+        isKeyTakeaways -> KeyTakeawaysDisplay,
         isShowcase -> ShowcaseDisplay
       )
 

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Display.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Display.scala
@@ -6,4 +6,5 @@ case object StandardDisplay extends Display
 case object ImmersiveDisplay extends Display
 case object ShowcaseDisplay extends Display
 case object NumberedListDisplay extends Display
+case object KeyTakeawaysDisplay extends Display
 case object ColumnDisplay extends Display

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -716,6 +716,13 @@ class CapiModelEnrichmentFormatTest extends FlatSpec with MockitoSugar with Matc
     f.content.display shouldEqual NumberedListDisplay
   }
 
+  it should "return a display of 'KeyTakeawaysDisplay' when a displayHint of keyTakeaways is set" in {
+    val f = fixture
+    when(f.content.fields) thenReturn Some(f.fields)
+    when(f.fields.displayHint) thenReturn Some("keyTakeaways")
+    f.content.display shouldEqual KeyTakeawaysDisplay
+  }
+
   it should "return a display of 'StandardDisplay' when no predicates are set" in {
     val f = fixture
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As part of the template OKR, we'll be using the displayHint logic to indicate to platforms that a certain article is specifically a key takeaways piece; this adds the relevant logic to the capi client which frontend pulls from. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

The updated test suite should be passing; further down the line (with subsequent platform PRs) we should be able to distinguish between a standard/immersive/numbered list display and a specific key takeaway one. 
