### PR TITLE
Bump capi models

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.10", "2.13.1")
-  val capiModelsVersion = "17.7.0"
+  val capiModelsVersion = "18.0.0"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"


### PR DESCRIPTION
Bumping CAPI models to v18.0.0 (deprecates recipe atom)