### PR TITLE
Fix bug in missing match case

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,10 +9,9 @@ val snapshotReleaseType = "snapshot"
 val snapshotReleaseSuffix = "-SNAPSHOT"
 
 lazy val versionSettingsMaybe = {
-  // Set by e.g. sbt -DRELEASE_TYPE=candidate|snapshot.
-  // For production release, don't set a RELEASE_TYPE variable
   sys.props.get("RELEASE_TYPE").map {
     case v if v == snapshotReleaseType => snapshotReleaseSuffix
+    case _ => ""
   }.map { suffix =>
     releaseVersion := {
       ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.9.7


### PR DESCRIPTION
## What does this change?

We recently began setting the $RELEASE_TYPE to `production` for automated prod releases after leaving it empty in the past. This broke the pattern matching which figures out the correct version name suffix.

<img width="1168" alt="Screenshot 2023-12-04 at 14 43 57" src="https://github.com/guardian/content-api-scala-client/assets/74187452/d4ef54ab-28ba-422d-bbdd-9719046a4e21">
