### PR TITLE
Prevent runtime incompatibility with 'early-semver' `content-api-models-scala`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.18", "2.13.12")
-  val capiModelsVersion = "18.0.0"
+  val capiModelsVersion = "18.0.1"
   val thriftVersion = "0.15.0"
   val commonsCodecVersion = "1.10"
   val scalaTestVersion = "3.0.8"


### PR DESCRIPTION
Now that https://github.com/guardian/content-api-models/pull/232 has been merged, updating `content-api-models` to use  [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) and releasing [v18.0.1](https://github.com/guardian/content-api-models/releases/tag/v18.0.1), the [`content-api-models` artifacts](https://index.scala-lang.org/guardian/content-api-models/artifacts/content-api-models-scala) _declare_ themselves to adhere to '[early-semver](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#early-semver-and-sbt-version-policy)' - and even more than that, thanks to `sbt-version-policy`, they actually _do_ adhere to it!

This should mean that it is **no longer possible** for a single project that depends on `content-api-scala-client` & `content-api-models` to have _incompatible_ versions of those artifacts - sbt will reject the incompatibility [**at compile time**](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#versionscheme-librarydependencyschemes-and-sbt-150), where it can be fixed by just ensuring that all libraries (eg including `facia-scala-client`) have all been compiled against the same versions.

This should prevent **horrible runtime compatibility errors** like https://github.com/guardian/facia-scala-client/issues/301, which occurred with the rollout of the innocent-looking changes in `facia-scala-client` [v4.0.6](https://github.com/guardian/facia-scala-client/releases/tag/v4.0.6).
