### PR TITLE
Update CAPI model to 20.1.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.13")
-  val capiModelsVersion = "19.0.1"
+  val capiModelsVersion = "20.1.0"
   val thriftVersion = "0.19.0"
   val commonsCodecVersion = "1.16.1"
   val scalaTestVersion = "3.0.9"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates to latest CAPI model, including [v20.0.0](https://github.com/guardian/content-api-models/releases/tag/v20.0.0) for the new List element and [v20.1.0](https://github.com/guardian/content-api-models/releases/tag/v20.1.0) for the new Quick-Cryptic crossword

