### PR TITLE
Test content-api-model preview version for content-entity

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.13")
-  val capiModelsVersion = "23.0.0"
+  val capiModelsVersion = "24.0.0"
   val thriftVersion = "0.19.0"
   val commonsCodecVersion = "1.16.1"
   val scalaTestVersion = "3.0.9"


### PR DESCRIPTION
We are bumping preview version of `content-api-model` that as got `content-entity`'s latest release version to test - https://github.com/guardian/content-entity/actions/runs/8439281276
The other PR for reference: https://github.com/guardian/content-api-models/pull/246

Co-authored: @rtyley 

## How to test

Make a preview release and test in any of client consuming this library, we are going to try it in `apple-news`.

## How can we measure success?

Application should run fine and should not have no conflicts in version or errors in the test.
