### PR TITLE
Fix EnricoMi error on failing CI

### DIFF
--- a/.github/workflows/testonpush.yml
+++ b/.github/workflows/testonpush.yml
@@ -31,7 +31,7 @@ jobs:
           JAVA_OPTS: -XX:+UseCompressedOops
         run: sbt test
 
-      - uses: EnricoMi/publish-unit-test-result-action@v1
+      - uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()  #runs even if there is a test failure
         with:
           files: junit-tests/*.xml


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This test workflow intermittently fails: https://github.com/guardian/content-api-scala-client/actions/runs/8540280736/job/23397082405?pr=414. 

Upgrading EnricoMi seems to fix this flakiness (see https://github.com/guardian/apple-news/pull/320). 