### PR TITLE
Various CI fixes, including avoiding `push` as a CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
-name: Test on push
-
+name: CI
 on:
+  workflow_dispatch:
+  pull_request:
+
+  # triggering CI default branch improves caching
+  # see https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
   push:
-    branches: [ "**" ]
-  workflow_dispatch: {}
+    branches:
+      - main
 
 jobs:
   test:
@@ -15,10 +19,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: corretto
           java-version: 11

--- a/.github/workflows/testonpush.yml
+++ b/.github/workflows/testonpush.yml
@@ -27,11 +27,10 @@ jobs:
       - name: Test
         env:
           CAPI_TEST_KEY: ${{ secrets.CAPI_TEST_KEY }}
-          SBT_JUNIT_OUTPUT: ./junit-tests
           JAVA_OPTS: -XX:+UseCompressedOops
         run: sbt test
 
       - uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()  #runs even if there is a test failure
         with:
-          files: junit-tests/*.xml
+          files: test-results/**/TEST-*.xml

--- a/build.sbt
+++ b/build.sbt
@@ -61,5 +61,4 @@ lazy val defaultClientSettings: Seq[Setting[_]] = Seq(
   """
 )
 
-
-Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit-tests"))
+Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o")

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val root = (project in file("."))
       checkSnapshotDependencies,
       inquireVersions,
       runClean,
+      runTest,
       setReleaseVersion,
       commitReleaseVersion,
       tagRelease,

--- a/build.sbt
+++ b/build.sbt
@@ -62,4 +62,4 @@ lazy val defaultClientSettings: Seq[Setting[_]] = Seq(
 )
 
 
-Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"))
+Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit-tests"))


### PR DESCRIPTION
## What does this change?

Co-authored: @rtyley 

We are making various CI fixes including using pull request trigger(https://github.com/guardian/content-api-scala-client/pull/417/commits/0e4149eccbb397b4a430d10da9dc31bc8be89315)
because `push` event is very bad choice of trigger for CI on github PRs.
 Example: https://github.com/guardian/mobile-apps-api/pull/2760

We also updating Test results to get accumulated in `test-results` folder.

## How to test

Raise this as PR (not Draft) and observe CI tests.

## How can we measure success?

CI tests should pass on PR
