### PR TITLE
Fix permission for EnricoMi actions

### DIFF
--- a/.github/workflows/testonpush.yml
+++ b/.github/workflows/testonpush.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
       contents: read
       checks: write
-      issues: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this change?

As mentioned in EnricoMi documentation https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#permissions

We have to set the permission which we have missed in last PR where we have updated Enricomi v1 to v2 : https://github.com/guardian/content-api-scala-client/pull/416

## How to test

Raise this as PR (not Draft) and observe CI tests.

## How can we measure success?

CI tests should pass
