### PR TITLE
Add support for internal-all-channels

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -74,7 +74,8 @@ case class ItemQuery(id: String, parameterHolder: Map[String, Parameter] = Map.e
   with UseDateParameter[ItemQuery]
   with FilterParameters[ItemQuery]
   with FilterExtendedParameters[ItemQuery]
-  with FilterSearchParameters[ItemQuery] {
+  with FilterSearchParameters[ItemQuery]
+  with InternalParameters[ItemQuery] {
 
   def withParameters(parameterMap: Map[String, Parameter]) = copy(id, parameterMap)
 
@@ -347,6 +348,17 @@ trait FilterSectionParameters[Owner <: Parameters[Owner]] extends Parameters[Own
 trait FilterSearchParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
   def q = StringParameter("q")
   def queryFields = StringParameter("query-fields")
+}
+
+trait InternalParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>
+  /**
+    * Requests that results for /internal-code/?? paths are returned from Live even if they are
+    * not published to the website [Open Channel]. No effect on Preview as they are returned even if unpublished then.
+    * No effect if the active key is not Internal tier, or the request is not an item-retrieval for an internal-code of the
+    * article.
+    * @return
+    */
+  def internalAllChannels = BoolParameter("internal-all-channels")
 }
 
 trait AtomsParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>

--- a/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
@@ -14,6 +14,11 @@ class ContentApiQueryTest extends AnyFlatSpec with Matchers  {
       "/profile/justin-pinner?show-alias-paths=true"
   }
 
+  "ItemQuery" should "include the internal-all-channels if requested" in {
+    ItemQuery("profile/justin-pinner").internalAllChannels(true).getUrl("") shouldEqual
+      "/profile/justin-pinner?internal-all-channels=true"
+  }
+
   "SearchQuery" should "also be excellent" in {
     SearchQuery().tag("profile/robert-berry").showElements("all").contentType("article").queryFields("body").getUrl("") shouldEqual
       "/search?tag=profile%2Frobert-berry&show-elements=all&type=article&query-fields=body"


### PR DESCRIPTION
## What does this change?

Adds support for the proposed internal-all-channels flag, introduced to Concierge in the PR https://github.com/guardian/content-api/pull/2881

**NOTE** - draft pending full review of above Concierge PR

## How to test

- Ensure that the right branch of Concierge is deployed to CODE
- Write up a test program to retrieve the articles as per the Concierge PR linked above
- Check that you get the same responses

## How can we measure success?

Able to make `internal-code` requests irrespective of channel, through the library.  **Not** able to accidentally expose content.

## Have we considered potential risks?
