### PR TITLE
Add "withChannel" parameter for search and get

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/ContentApiClient.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/ContentApiClient.scala
@@ -165,7 +165,6 @@ trait ContentApiQueries {
   val editions = EditionsQuery()
   val atoms = AtomsQuery()
   def atomUsage(atomType: AtomType, atomId: String) = AtomUsageQuery(atomType, atomId)
-  val recipes = RecipesQuery()
   val reviews = ReviewsQuery()
   val gameReviews = GameReviewsQuery()
   val restaurantReviews = RestaurantReviewsQuery()

--- a/client/src/main/scala/com.gu.contentapi.client/ContentApiClient.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/ContentApiClient.scala
@@ -165,6 +165,8 @@ trait ContentApiQueries {
   val editions = EditionsQuery()
   val atoms = AtomsQuery()
   def atomUsage(atomType: AtomType, atomId: String) = AtomUsageQuery(atomType, atomId)
+  @deprecated("Recipe atoms no longer exist and should not be relied upon. No data will be returned and this query will be removed in a future iteration of the library")
+  val recipes = RecipesQuery()
   val reviews = ReviewsQuery()
   val gameReviews = GameReviewsQuery()
   val restaurantReviews = RestaurantReviewsQuery()

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -102,7 +102,7 @@ case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty, chan
   /**
     * Make this search on a CAPI channel rather than against web-only content
     * For more information about channels, and the reason why your app should only be in one channel,
-    * content the Content API team
+    * contact the Content API team
     * @param channelId the channel to search against, or "all" to search across all channels.
     */
   def withChannel(channelId:String):SearchQuery = copy(parameterHolder, Some(channelId))
@@ -192,6 +192,17 @@ case class AtomUsageQuery(atomType: AtomType, atomId: String, parameterHolder: M
   def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterHolder = parameterMap)
 
   override def pathSegment: String = s"atom/${atomType.toString.toLowerCase}/$atomId/usage"
+}
+
+@deprecated("Recipe atoms no longer exist and should not be relied upon. No data will be returned and this class will be removed in a future iteration of the library")
+case class RecipesQuery(parameterHolder: Map[String, Parameter] = Map.empty)
+  extends ContentApiQuery[AtomsResponse]
+    with PaginationParameters[RecipesQuery]
+    with RecipeParameters[RecipesQuery] {
+
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
+
+  override def pathSegment: String = "atoms/recipes"
 }
 
 case class ReviewsQuery(parameterHolder: Map[String, Parameter] = Map.empty)

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -63,7 +63,7 @@ trait SearchQueryBase[Self <: SearchQueryBase[Self]]
   this: Self =>
 }
 
-case class ItemQuery(id: String, parameterHolder: Map[String, Parameter] = Map.empty)
+case class ItemQuery(id: String, parameterHolder: Map[String, Parameter] = Map.empty, channelId: Option[String]=None)
   extends ContentApiQuery[ItemResponse]
   with EditionParameters[ItemQuery]
   with ShowParameters[ItemQuery]
@@ -76,12 +76,19 @@ case class ItemQuery(id: String, parameterHolder: Map[String, Parameter] = Map.e
   with FilterExtendedParameters[ItemQuery]
   with FilterSearchParameters[ItemQuery] {
 
-  def withParameters(parameterMap: Map[String, Parameter]) = copy(id, parameterMap)
+  def withParameters(parameterMap: Map[String, Parameter]) = copy(id, parameterMap, channelId)
+
+  def withChannelId(newChannel:String) = copy(id, parameterHolder, Some(newChannel))
+
+  def withoutChannelId() = copy(id, parameterHolder, None)
 
   def itemId(contentId: String): ItemQuery =
     copy(id = contentId)
 
-  override def pathSegment: String = id
+  override def pathSegment: String = channelId match {
+    case None => id
+    case Some(chl) => s"channel/$chl/item/$id"
+  }
 }
 
 case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty, channelId: Option[String] = None)
@@ -185,16 +192,6 @@ case class AtomUsageQuery(atomType: AtomType, atomId: String, parameterHolder: M
   def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterHolder = parameterMap)
 
   override def pathSegment: String = s"atom/${atomType.toString.toLowerCase}/$atomId/usage"
-}
-
-case class RecipesQuery(parameterHolder: Map[String, Parameter] = Map.empty)
-  extends ContentApiQuery[AtomsResponse]
-  with PaginationParameters[RecipesQuery]
-  with RecipeParameters[RecipesQuery] {
-
-  def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterMap)
-
-  override def pathSegment: String = "atoms/recipes"
 }
 
 case class ReviewsQuery(parameterHolder: Map[String, Parameter] = Map.empty)

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -305,6 +305,7 @@ trait ShowParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { thi
   def showStats = BoolParameter("show-stats")
   def showAliasPaths = BoolParameter("show-alias-paths")
   def showSchemaOrg = BoolParameter("show-schemaorg")
+  def showChannels = StringParameter("show-channels")
 }
 
 trait ShowReferencesParameters[Owner <: Parameters[Owner]] extends Parameters[Owner] { this: Owner =>

--- a/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
@@ -14,6 +14,16 @@ class ContentApiQueryTest extends AnyFlatSpec with Matchers  {
       "/profile/justin-pinner?show-alias-paths=true"
   }
 
+  "ItemQuery" should "accept a channel" in {
+    ItemQuery("lifeandstyle/thing").withChannelId("recipes").getUrl("") shouldEqual
+      "/channel/recipes/item/lifeandstyle/thing"
+  }
+
+  "ItemQuery" should "drop the included channel if asked" in {
+    ItemQuery("lifeandstyle/thing").withChannelId("recipes").withoutChannelId().getUrl("") shouldEqual
+      "/lifeandstyle/thing"
+  }
+
   "SearchQuery" should "also be excellent" in {
     SearchQuery().tag("profile/robert-berry").showElements("all").contentType("article").queryFields("body").getUrl("") shouldEqual
       "/search?tag=profile%2Frobert-berry&show-elements=all&type=article&query-fields=body"

--- a/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/ContentApiQueryTest.scala
@@ -29,6 +29,16 @@ class ContentApiQueryTest extends AnyFlatSpec with Matchers  {
       "/search?paths=path%2Fone%2Cpath%2Ftwo"
   }
 
+  "SearchQuery" should "include a channel if asked" in {
+    SearchQuery().withChannel("my-channel").paths("path/one").getUrl("") shouldEqual
+      "/channel/my-channel/search?paths=path%2Fone"
+  }
+
+  "SearchQuery" should "drop the included channel if asked" in {
+    SearchQuery().withChannel("my-channel").withoutChannel().paths("path/one").getUrl("") shouldEqual
+      "/search?paths=path%2Fone"
+  }
+
   "SectionsQuery" should "be beautiful" in {
     SectionsQuery().getUrl("") shouldEqual "/sections"
   }


### PR DESCRIPTION
## What does this change?

Exposes the functionality introduced in https://github.com/guardian/content-api/pull/2882, by allowing a user to search within a channel using a "withChannel()" builder method on the query:

```scala
ContentApiClient.search().withChannel("my-channel").....
ContentApiClient.item("item-path").withChannel("my-channel")...
```

## How to test

Tests are provided in the spec files, duplicate this in your own project

## How can we measure success?

Able to make channelled requests with CSC
