### PR TITLE
Temporarily disable compability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
   .aggregate(client, defaultClient)
   .settings(
     publish / skip := true,
-    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+//    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq(
       checkSnapshotDependencies,
       inquireVersions,


### PR DESCRIPTION
This will allow us to make a release after a failed release (https://github.com/guardian/content-api-scala-client/actions/runs/9693794085/job/26750274886)

See https://github.com/guardian/gha-scala-library-release-workflow/issues/33