### PR TITLE
Re-enable compatability checking

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
   .aggregate(client, defaultClient)
   .settings(
     publish / skip := true,
-//    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq(
       checkSnapshotDependencies,
       inquireVersions,


### PR DESCRIPTION
Now that we have successfully released the library again, we can re-enable compatibility checking