### PR TITLE
Make the ContentApiQuery type convariant in Response

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -8,7 +8,7 @@ import com.gu.contentapi.client.{Parameter, Parameters}
 import com.gu.contentatom.thrift.AtomType
 import com.twitter.scrooge.ThriftStruct
 
-sealed trait ContentApiQuery[Response <: ThriftStruct] {
+sealed trait ContentApiQuery[+Response <: ThriftStruct] {
   def parameters: Map[String, String]
 
   def pathSegment: String


### PR DESCRIPTION
## What does this change?

Changes the `Response` type parameter from invarant to covariant.

This is to make pattern-matching in tests to work better - used in integration tests introduced with https://github.com/guardian/crier/pull/169.

In a nutshell, we needed to be able to use Mockito to verify two different calls to the library.  If the calls changed order, the behaviour would still be correct (ordering cannot be guaranteed in this case) but the test would then fail if it tried to cast the `SearchQuery` to the `ItemQuery` or vice-versa.

With this update in place, we can make a correctly scoped `match` statement to handle both of these cases gracefully:

```
      verify(mockLiveContentApi, times(2)).getResponse(argThat((arg:ContentApiQuery[ThriftStruct])=> arg match {
        case searchQuery: SearchQuery=>
          searchQuery.channelId.contains("all") &&
            searchQuery.parameters.get("ids").contains(s"internal-code/composer/${notifications.head.value.composerId}") &&
            searchQuery.parameters.get("show-channels").contains("all")
        case itemQuery: ItemQuery=>
          itemQuery.channelId.contains("all") &&
            itemQuery.id=="lifeandstyle/article/2024/jun/27/bzbcxvzxvzxv"
        case other@_ =>
          fail(s"Unexpected CAPI call: ${other.getClass.getTypeName}")
      }))(any, any)
```

Without this update, the compiler objects since the type signature of `ContentApiQuery[Response]` requires specific response type and not an ancestor of this type.  When changed to `ContentApiQuery[+Response]` we are able to successfully match against any possible value.

## How to test

Integration tests linked above work.

Tested locally.

## How can we measure success?

Able to continue on Crier

## Have we considered potential risks?

n/a
