### PR TITLE
Remove `PrintShopDesign`

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -41,8 +41,6 @@ object CapiModelEnrichment {
 
   val isGallery: ContentFilter = tagExistsWithId("type/gallery")
 
-  val isPrintShop: ContentFilter = content => !isPictureContent(content) && tagExistsWithId("artanddesign/series/guardian-print-shop")(content)
-
   // The date used here is arbitrary and will be moved nearer to the present when the new template feature is ready to be used in production
   val immersiveInteractiveSwitchoverDate = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
   
@@ -103,7 +101,6 @@ object CapiModelEnrichment {
         isFullPageInteractive -> FullPageInteractiveDesign,
         isInteractive -> InteractiveDesign,
         tagExistsWithId("info/newsletter-sign-up") -> NewsletterSignupDesign,
-        isPrintShop -> PrintShopDesign,
         isGallery -> GalleryDesign,
         isPictureContent -> PictureDesign,
         tagExistsWithId("type/audio") -> AudioDesign,

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
@@ -23,7 +23,6 @@ case object EditorialDesign extends Design
 case object QuizDesign extends Design
 case object InteractiveDesign extends Design
 case object PhotoEssayDesign extends Design
-case object PrintShopDesign extends Design
 case object ObituaryDesign extends Design
 case object NewsletterSignupDesign extends Design
 case object TimelineDesign extends Design

--- a/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
+++ b/client/src/test/scala/com.gu.contentapi.client/model/utils/CapiModelEnrichmentTest.scala
@@ -212,13 +212,6 @@ class CapiModelEnrichmentFormatTest extends AnyFlatSpec with MockitoSugar with M
 
   behavior of "Format.design"
 
-  it should "have a design of 'PrintShopDesign' when tag artanddesign/series/guardian-print-shop is present" in {
-    val f = fixture
-    when(f.tag.id) thenReturn "artanddesign/series/guardian-print-shop"
-
-    f.content.design shouldEqual PrintShopDesign
-  }
-
   it should "have a design of PictureDesign when tag artanddesign/series/guardian-print-shop is present on Picture content" in {
     val f = fixture
     when(f.tag.id) thenReturn "artanddesign/series/guardian-print-shop"


### PR DESCRIPTION
We no longer intend to handle this as a separate `Design`. Anything that was previously `PrintShop` will now be one of the other `Design`s. This change will require updates in DCAR and frontend.

See also the equivalent change in `guardian/libs`: https://github.com/guardian/csnx/pull/1683
