### PR TITLE
Prefer `.headOption` over `.head`

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -215,7 +215,7 @@ object CapiModelEnrichment {
         val hasShowcaseImage = for {
           blocks <- content.blocks
           main <- blocks.main
-          mainMedia = main.elements.head
+          mainMedia <- main.elements.headOption
           imageTypeData <- mainMedia.imageTypeData
           imageRole <- imageTypeData.role
         } yield {


### PR DESCRIPTION
There should always be an element if the main media exists, but we have found one example where this wasn't true in Pre-Publication/Preview content.

This should hopefully fix an issue that we have seen in production (well, preview)

Stack trace that this should avoid:

```
java.util.NoSuchElementException: head of empty list
	at scala.collection.immutable.Nil$.head(List.scala:663)
	at scala.collection.immutable.Nil$.head(List.scala:662)
	at com.gu.contentapi.client.utils.CapiModelEnrichment$RenderingFormat$.$anonfun$display$4(CapiModelEnrichment.scala:218)
	at scala.Option.map(Option.scala:242)
	at com.gu.contentapi.client.utils.CapiModelEnrichment$RenderingFormat$.$anonfun$display$3(CapiModelEnrichment.scala:217)
	at scala.Option.flatMap(Option.scala:283)
	at com.gu.contentapi.client.utils.CapiModelEnrichment$RenderingFormat$.$anonfun$display$2(CapiModelEnrichment.scala:216)
	at com.gu.contentapi.client.utils.CapiModelEnrichment$RenderingFormat$.$anonfun$display$2$adapted(CapiModelEnrichment.scala:214)
	at com.gu.contentapi.client.utils.CapiModelEnrichment$RenderingFormat$.$anonfun$display$19(CapiModelEnrichment.scala:254)
	at com.gu.contentapi.client.utils.CapiModelEnrichment$RenderingFormat$.$anonfun$display$19$adapted(CapiModelEnrichment.scala:252)
	at com.gu.contentapi.client.utils.CapiModelEnrichment$$anonfun$getFromPredicate$1.applyOrElse(CapiModelEnrichment.scala:18)
	at com.gu.contentapi.client.utils.CapiModelEnrichment$$anonfun$getFromPredicate$1.applyOrElse(CapiModelEnrichment.scala:18)
```