### PR TITLE
Add crossword design

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -105,6 +105,7 @@ object CapiModelEnrichment {
         isPictureContent -> PictureDesign,
         tagExistsWithId("type/audio") -> AudioDesign,
         tagExistsWithId("type/video") -> VideoDesign,
+        tagExistsWithId("type/crossword") -> CrosswordDesign,
         isReview -> ReviewDesign,
         isObituary -> ObituaryDesign,
         tagExistsWithId("tone/analysis") -> AnalysisDesign,

--- a/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/format/Design.scala
@@ -7,6 +7,7 @@ case object GalleryDesign extends Design
 case object PictureDesign extends Design
 case object AudioDesign extends Design
 case object VideoDesign extends Design
+case object CrosswordDesign extends Design
 case object ReviewDesign extends Design
 case object AnalysisDesign extends Design
 case object ExplainerDesign extends Design


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We are updating DCR to support crosswords. To create a new layout in DCR, we need to extend the Design model to support crosswords.

This change also has to be made in the CAPI client because frontend uses it to parse the CAPI data into the `Format` type, before sending this on to DCR.

## How to test

For a crossword page, check the JSON data passed from frontend to DCR ([example](https://www.theguardian.com/crosswords/quick/17058.json?dcr)). The format should be defined as:

```json
"format": {
  "design": "CrosswordDesign",
  "theme": "LifestylePillar",
  "display": "StandardDisplay"
}
```

