### PR TITLE
Bump CAPI model to include list element changes

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "25.1.0"
+  val capiModelsVersion = "26.0.0"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
### What does this change?

Updates `content-api-model` to the latest version which includes a change to the list element fields:

https://github.com/guardian/content-api-models/releases/tag/v26.0.0

This is needed so `frontend` can be updated to know about these fields