### PR TITLE
Bump models to get new deeply read field

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "26.0.0"
+  val capiModelsVersion = "27.0.0"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
## What does this change?

https://github.com/guardian/content-api-models/pull/258

There is a new deeply-read field in the model.
