### PR TITLE
Remove isGallery condition from isImmersiveDisplay

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -209,8 +209,7 @@ object CapiModelEnrichment {
       // https://github.com/guardian/frontend/blob/e71dc1c521672b28399811c59331e0c2c713bf00/common/app/model/content.scala#L86
       val isImmersiveDisplay: ContentFilter = content =>
         isImmersive(content) ||
-          isPhotoEssay(content) ||
-          isGallery(content)
+          isPhotoEssay(content)
 
       def hasShowcaseImage: ContentFilter = content => {
         val hasShowcaseImage = for {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR updates the CAPI client by removing the check for Gallery articles in the isImmersiveDisplay filter. Previously, Gallery articles were incorrectly considered to have an immersive display.
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Tested in frontend using the published preview version `34.1.1-PREVIEW.remove-gallery-from-immersive-display.2025-06-02T1020.8e77bc41` 