### PR TITLE
Bump CAPI model to bring in new podcast fields

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "27.1.0"
+  val capiModelsVersion = "28.0.0-PREVIEW.add-episodic-artwork-fields.2025-06-17T0819.478ca91c"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
## What does this change?

This PR pulls in https://github.com/guardian/content-api-models/pull/261, which supports two new podcast metadata fields.

This PR is required to allow itunes-rss to query for this field.

## How to test

This will only be testable once we have a branch in itunes-rss which consumes this new version of the CAPI client.
