### PR TITLE
Bump CAPI model to include new podcast fields

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "29.0.0"
+  val capiModelsVersion = "30.0.0-PREVIEW.add-new-podcast-fields.2025-08-07T1437.73d8c924"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "30.0.0-PREVIEW.add-new-podcast-fields.2025-08-28T1513.9b26e163"
+  val capiModelsVersion = "30.0.0"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "30.0.0-PREVIEW.add-new-podcast-fields.2025-08-07T1437.73d8c924"
+  val capiModelsVersion = "30.0.0-PREVIEW.add-new-podcast-fields.2025-08-28T1513.9b26e163"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
## What does this change?

This PR pulls in https://github.com/guardian/content-api-models/pull/262, which supports three new podcast fields.

This PR is required to allow itunes-rss to retrieve these fields

## How to test

This will only be testable once we have a branch in `itunes-rss` which consumes this new version of the CAPI client.

## Related PRs

- [flexible-model](https://github.com/guardian/flexible-model/pull/82)
- [flexible-content](https://github.com/guardian/flexible-content/pull/5768)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3149)
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3180)
- [content-api-models](https://github.com/guardian/content-api-models/pull/262) 
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/3150)
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/445) <- you are here
- [itunes-rss](https://github.com/guardian/itunes-rss/pull/183)
