### PR TITLE
Bump capi models to include latest content-atom model changes (6.1.0)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "30.0.0"
+  val capiModelsVersion = "31.0.0"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
## What does this change?

Brings in https://github.com/guardian/content-api-models/releases/tag/v31.0.0 which brings in https://github.com/guardian/content-atom/releases/tag/v6.1.0.