### PR TITLE
Bump CAPI models to support new media atom fields

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "32.0.0-PREVIEW.bump-content-atom-to-support-looping-video-field.2025-10-29T1136.98f8ace6"
+  val capiModelsVersion = "33.0.0"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "32.0.0-PREVIEW.bump-content-atom-to-support-looping-video-field.2025-10-20T1408.e9ccee62"
+  val capiModelsVersion = "32.0.0-PREVIEW.bump-content-atom-to-support-looping-video-field.2025-10-22T0759.e9ccee62"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "31.1.0"
+  val capiModelsVersion = "32.0.0-PREVIEW.bump-content-atom-to-support-looping-video-field.2025-10-20T1408.e9ccee62"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "32.0.0-PREVIEW.bump-content-atom-to-support-looping-video-field.2025-10-22T0759.e9ccee62"
+  val capiModelsVersion = "32.0.0-PREVIEW.bump-content-atom-to-support-looping-video-field.2025-10-29T1136.98f8ace6"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
## What does this change?

Bump CAPI models to support new media atom fields introduced here: https://github.com/guardian/content-api-models/pull/271

This will allow frontend to access the new fields.

## How to test

We can only test this change once we have a frontend branch which consumes this library.

## Related PRs

- [content-atom](https://github.com/guardian/content-atom/pull/184)
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3218)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3219)
- [content-api-models](https://github.com/guardian/content-api-models/pull/271)
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/3220)
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/460) <- you are here
- [facia-scala-client](https://github.com/guardian/facia-scala-client/pull/369)
- [frontend](https://github.com/guardian/frontend/pull/28326)
