### PR TITLE
Add calloutType field to callout element

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "34.0.0"
+  val capiModelsVersion = "34.0.0-PREVIEW.pm-callout-type.2025-11-14T1725.7389da8b"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
## What does this change?
This pr is part of an effort to replace the quick guide atoms in stories such as [this one](https://www.theguardian.com/politics/2025/oct/10/boris-johnson-breached-rules-designed-to-stop-abuse-of-contacts-made-in-public-office-watchdog-finds) with a callout made in the targeting tool. The motivation is to prevent callout text from being shared with syndication partners.

To do this, I'm introduce a new type of callout - 'reporter callout' - which differs from the existing 'callout' (which is really a 'community callout') in that it is a lot simpler, with no associated Tag or Form stack form. The rendering will also differ. With that in mind, we need a way to distinguish between the existing 'callout' elements and these new reporter callouts. This PR adds a new 'calloutType' field to the callout fields type.

## How to test
Needs testing on CODE