### PR TITLE
Bump CAPI model to include new video captions field

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  // val capiModelsVersion = "37.0.0"
-  val capiModelsVersion = "38.0.0-PREVIEW.rjr-add-new-caption-field-to-capi-model.2026-04-08T1528.c2707d49"
+  val capiModelsVersion = "39.0.0"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
   // val capiModelsVersion = "37.0.0"
-  val capiModelsVersion = "v38.0.0-PREVIEW.rjr-add-new-caption-field-to-capi-model.2026-04-08T1528.c2707d49"
+  val capiModelsVersion = "38.0.0-PREVIEW.rjr-add-new-caption-field-to-capi-model.2026-04-08T1528.c2707d49"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,8 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "37.0.0"
+  // val capiModelsVersion = "37.0.0"
+  val capiModelsVersion = "v38.0.0-PREVIEW.rjr-add-new-caption-field-to-capi-model.2026-04-08T1528.c2707d49"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
## What does this change?

Composer users need an easier way to update captions for video atoms. The current process of updating them in MAM is laborious and prevents us from showing different captions for the same video on different articles, which is sometimes helpful.

The work in this PR is part of a chain of PRs to add a new `caption` field to the atom editor in Composer. This field should:
- Default to the Media atom's `title` value, set in the Media Atom Maker tool
- Be editable within Composer
- Allow users to clear the field, which would remove the caption entirely from videos used in an article (including standfirst videos)

See the [Rethink media atom captions in Composer](https://github.com/guardian/articles-and-publishing/issues/351) issue (in the Arts&Pubs project) for further details

- [flexible-model](https://github.com/guardian/flexible-model/pull/92) [includes release] - testing in CODE complete
- [flexible-content](https://github.com/guardian/flexible-content/pull/6451) - testing in CODE complete
- [content-api-models](https://github.com/guardian/content-api-models/pull/296) [includes release] - testing in CODE complete
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3330) - testing in CODE complete
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3331) - testing in CODE complete
- [content-api (Concierge) ](https://github.com/guardian/content-api/pull/3332)
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/478) [includes release] **← ← ← We are here**
- [content-api-firehose-client](https://github.com/guardian/content-api-firehose-client/pull/96) [includes release]
- [facia-scala-client](https://github.com/guardian/facia-scala-client/pull/391)
- [frontend](https://github.com/guardian/frontend/pull/28728)
- [dotcom-rendering](https://github.com/guardian/dotcom-rendering/pull/15717)
- [apple-news](https://github.com/guardian/apple-news/pull/578)

### Testing

- All PRs in the chain are expected to pass local testing requirements specific to their repo.
- All PRs in the chain will need to pass toolchain and CI tests required by their repo when pushing the branch to remote.

[Testing plan document](https://docs.google.com/document/d/1yXy4sb4_ZJvOUVzpUmWHC0vlIoiyYY9KYdPX1VIA94w/edit?tab=t.0)

### Deployment
Some PRs include model pre-releases. Before deploying to PROD, these pre-releases will need to become full releases, and code in affected PRs updated to reflect these changes.

TODO: come up with an appropriate sequencing for merging and closing PRs. The PRs do not need to all be deployed at the same time, but some - such as those requiring associated releases - need to be performed before others.
