### PR TITLE
Bump capiModelsVersion to 38.0.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "37.0.0"
+  val capiModelsVersion = "38.0.0"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
## What does this change?
Bump CAPI models to version 38  to support new media atom fields.

This reflects the changes made in https://github.com/guardian/content-api-models/pull/297

## How has this change been tested?
This can be tested in Frontend by deploying the following branche to CODE: https://github.com/guardian/frontend/pull/28750


## How can we measure success?
Platforms can read the new media atom fields.

## Relevant PRs

- [content-atom](https://github.com/guardian/content-atom/pull/208)
- [atom-maker](https://github.com/guardian/atom-maker/pull/141)
- [content-api (ES mappings)](https://github.com/guardian/content-api/pull/3335)
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3336)
- [content-api-models](https://github.com/guardian/content-api-models/pull/297)
- [content-api (Concierge)](https://github.com/guardian/content-api/pull/3337) 
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/479)<- you are here

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214233011635842