### PR TITLE
Reverting to v41.2.1-SNAPSHOT 

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "42.0.1-SNAPSHOT"
+ThisBuild / version := "41.2.1-SNAPSHOT"


### PR DESCRIPTION
Releasing v42.0.0 failed before it landed in sonatype so I'm following the instructions in https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md#troubleshooting to try again.