### PR TITLE
Disable compatibility checking to resolve broken release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
   .aggregate(client, defaultClient)
   .settings(
     publish / skip := true,
-    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+//    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq(
       checkSnapshotDependencies,
       inquireVersions,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "42.0.0"
+ThisBuild / version := "42.0.1-SNAPSHOT"


### PR DESCRIPTION
Releasing v42.0.0 failed due to a network timeout. Since v42.0.0 isn't in Maven, but Github thinks it exists, subsequent attempts to assess compatibility with v42.0.0 will always fail.

To resolve this situation we are temporarily disabling the compatibility check, and preparing version.sbt for a v42.0.1 release.

Once we have successfully released v42.0.1 we will re-enable compatibility checking.