### PR TITLE
Bump capi to include product element ID

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "38.0.0"
+  val capiModelsVersion = "41.0.0"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps CAPI to add an ID field to the product element. We need an ID field per product because we are planning on creating a summary element with a relationship to products. This should also be a future proofing for potentially having a product database later. The field will be populated with a generated UUID.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

Tested with preview versions in Frontend

## Deployment chain

- [flexible-model](https://github.com/guardian/flexible-model/pull/93) [includes release] 
- [flexible-content](https://github.com/guardian/flexible-content/pull/6533)
- [content-api-models](https://github.com/guardian/content-api-models/pull/302) [includes release]
- [content-api (Porter)](https://github.com/guardian/content-api/pull/3341)
- [content-api (ES mappings](https://github.com/guardian/content-api/pull/3342)
- [content-api (Concierge)](https://github.com/guardian/content-api/pull/3344)
- [content-api-scala-client](https://github.com/guardian/content-api-scala-client/pull/484) [includes release] ← ← ← We are here
- [content-api-firehose-client](https://github.com/guardian/content-api-firehose-client/pull/) [includes release] 
- [facia-scala-client](https://github.com/guardian/facia-scala-client/pull/394) [includes release] 
- [frontend](https://github.com/guardian/frontend/pull/28766) 
- [dotcom-rendering](https://github.com/guardian/dotcom-rendering/pull/15780)
- [apple-news](https://github.com/guardian/apple-news/pull/) N/A