### PR TITLE
Bump CAPI model to support product summary element

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "44.0.0-PREVIEW.aheproduct-summary-element.2026-06-25T1458.232a9450"
+  val capiModelsVersion = "46.0.0"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "41.0.0"
+  val capiModelsVersion = "44.0.0-PREVIEW.aheproduct-summary-element.2026-06-25T1458.232a9450"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
   val capiModelsVersion = "46.0.0"
-  val thriftVersion = "0.20.0"
+  val thriftVersion = "0.23.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"
   val slf4jVersion = "2.0.13"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps CAPI models to support product summary element, see https://github.com/guardian/flexible-model/discussions/94 and PR chain:

flexible-model 
- https://github.com/guardian/flexible-model/pull/99 ✅🚢

flexible-content
-  https://github.com/guardian/flexible-content/pull/6593  ✅🚢

Content-api-models
- https://github.com/guardian/content-api-models/pull/311 ✅🚢

content-api (porter)
- https://github.com/guardian/content-api/pull/3363 ✅

content-api (concierge) 
- https://github.com/guardian/content-api/pull/3365 ✅

content-api (elastic search mappings)
- https://github.com/guardian/content-api/pull/3364 ✅🚢
