### PR TITLE
Extend auto-pagination to support `AtomUsageQuery`

### DIFF
--- a/client/src/main/scala/com.gu.contentapi.client/model/Decoder.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Decoder.scala
@@ -30,5 +30,5 @@ object Decoder {
   implicit val videoStatsDecoder: Decoder[VideoStatsResponse] = new Decoder(VideoStatsResponse)
   implicit val atomsDecoder: Decoder[AtomsResponse] = new Decoder(AtomsResponse)
   implicit val searchDecoder: PageableResponseDecoder[SearchResponse, Content] = pageableResponseDecoder(SearchResponse)(_.pageSize, _.results)
-  implicit val atomUsageDecoder: Decoder[AtomUsageResponse] = new Decoder(AtomUsageResponse)
+  implicit val atomUsageDecoder: PageableResponseDecoder[AtomUsageResponse, String] = pageableResponseDecoder(AtomUsageResponse)(_.pageSize, _.results)
 }

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -186,12 +186,20 @@ case class AtomsQuery(parameterHolder: Map[String, Parameter] = Map.empty)
 }
 
 case class AtomUsageQuery(atomType: AtomType, atomId: String, parameterHolder: Map[String, Parameter] = Map.empty)
-  extends ContentApiQuery[AtomUsageResponse]
+  extends PaginatedApiQuery[AtomUsageResponse, String]
   with PaginationParameters[AtomUsageQuery] {
 
   def withParameters(parameterMap: Map[String, Parameter]) = copy(parameterHolder = parameterMap)
 
   override def pathSegment: String = s"atom/${atomType.toString.toLowerCase}/$atomId/usage"
+
+  def setPaginationConsistentWith(response: AtomUsageResponse): PaginatedApiQuery[AtomUsageResponse, String] =
+    pageSize.setIfUndefined(response.pageSize)
+
+  protected override def followingQueryGivenFull(response: AtomUsageResponse, direction: Direction): Option[AtomUsageQuery] = {
+    val followingPage = response.currentPage + direction.delta
+    if (followingPage >= 1 && followingPage <= response.pages) Some(page(followingPage)) else None
+  }
 }
 
 @deprecated("Recipe atoms no longer exist and should not be relied upon. No data will be returned and this class will be removed in a future iteration of the library")


### PR DESCRIPTION
This follows on from https://github.com/guardian/content-api-scala-client/pull/359, which added auto-pagination support to `TagsQuery` - thanks to the refactor in that PR, this is a much smaller PR.

With this change auto-pagination is now supported by:

* `AtomUsageQuery`
* `TagsQuery` - both `AtomUsageQuery` & `TagsQuery` use basic page-number-based pagination
* `SearchQuery` - uses pagination based on last-returned-element

Example of a atom that is quite widely used (26 articles):

* https://atomworkshop.gutools.co.uk/atoms/GUIDE/08b8960f-4556-460f-aa40-601083c90627/stats - note this only has **12** entries...
* https://content.guardianapis.com/atom/guide/08b8960f-4556-460f-aa40-601083c90627/usage?api-key= ...while actually there are **26** - the tool is not paginating!
