### PR TITLE
Bump CAPI models to 44.0.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   val scalaVersions = Seq("2.12.19", "2.13.14")
-  val capiModelsVersion = "41.0.0"
+  val capiModelsVersion = "44.0.0"
   val thriftVersion = "0.20.0"
   val commonsCodecVersion = "1.17.0"
   val scalaTestVersion = "3.2.18"


### PR DESCRIPTION
## What does this change?

Bumps CAPI models to 44.0.0.

## How has this change been tested?

- [x] Compiles locally
- [x] CI passes

