### PR TITLE
Trigger manual release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
   .aggregate(client, defaultClient)
   .settings(
     publish / skip := true,
-    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+    //releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq(
       checkSnapshotDependencies,
       inquireVersions,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "46.0.1-SNAPSHOT"
+ThisBuild / version := "47.0.0-SNAPSHOT"


### PR DESCRIPTION
I was impatient and cancelled a Sonatype release, this is an attempt to get back to normal state as per [troubleshooting](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md#troubleshooting) suggestion