### PR TITLE
Drop support for Java 8

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-21.0.3.9.1
+java corretto-21

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val defaultClient = (project in file("client-default"))
 lazy val artifactProductionSettings: Seq[Setting[_]] = Seq(
   crossScalaVersions      := scalaVersions,
   scalaVersion            := scalaVersions.max,
-  scalacOptions           ++= Seq("-deprecation", "-unchecked", "-release:8"),
+  scalacOptions           ++= Seq("-deprecation", "-unchecked", "-release:11"),
   licenses                := Seq(License.Apache2),
   organization            := "com.gu"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.12.14


### PR DESCRIPTION
I don't believe this will be a controversial change! Java 8 was initially released in 2014, Java 11 in 2018.

At the Guardian we have no deployed EC2 instances using anything older than Java 11, and we would actually [recommend](https://docs.google.com/document/d/1ZR-YnaXCT5_gLVmTCeGs0mWd3KPaAozPjQK8uUzHZ9w/edit?tab=t.0#heading=h.p7e7kk73dtnv) Java 25 LTS.

## See also

* https://github.com/guardian/maintaining-scala-projects/issues/3