### PR TITLE
Drop support for Scala 2.12

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val scalaVersions = Seq("2.12.21", "2.13.18")
+  val scalaVersions = Seq("2.13.18")
   val capiModelsVersion = "47.0.0"
   val thriftVersion = "0.23.0"
   val commonsCodecVersion = "1.17.2"


### PR DESCRIPTION
This is a redo of:

* https://github.com/guardian/content-api-scala-client/pull/503

...I merged that PR, but not into the main branch! So here we go again...

https://metrics.gutools.co.uk/d/deuss7wisetc0f/guardian-scala-libraries-used-in-scala-2-12?orgId=1&from=now-6h&to=now&timezone=browser

The only 'real' use I can see of Scala 2.12 in projects that use content-api-scala-client is in Content API's DSU Recon:

* https://github.com/guardian/content-api/pull/3388 - this tool has not been recently used (wasn't used in the recent Elasticsearch migration in Content API) - If we want it back, we could easily recover it from git history and update it to Scala 2.13

## See also

* https://github.com/guardian/maintaining-scala-projects/issues/2