### PR TITLE
Add Cats Effect CAPI client (using `IO`)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,10 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 val ghProject = "content-api-client"
 
 lazy val root = (project in file("."))
-  .aggregate(client, defaultClient)
+  .aggregate(client, defaultClient, catsEffectClient)
   .settings(
     publish / skip := true,
-    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+    // releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq(
       checkSnapshotDependencies,
       inquireVersions,
@@ -30,6 +30,23 @@ lazy val client = (project in file("client"))
 lazy val defaultClient = (project in file("client-default"))
   .dependsOn(client)
   .settings(artifactProductionSettings, defaultClientSettings)
+  .settings(
+    name                :=  ghProject + "-default"
+  )
+
+lazy val catsEffectClient = (project in file("client-cats-effect"))
+  .dependsOn(client, defaultClient % "compile->compile;test->test")
+  .settings(artifactProductionSettings, defaultClientSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-core" % "2.13.0",
+      "org.typelevel" %% "cats-effect" % "3.7.0",
+      "co.fs2" %% "fs2-core" % "3.13.0",
+      "com.madgag" %% "bin-packing" % "2.0.0",
+      "org.typelevel" %% "weaver-cats" % "0.13.0" % Test
+    ),
+    name                :=  ghProject + "-cats-effect"
+  )
 
 
 lazy val artifactProductionSettings: Seq[Setting[?]] = Seq(
@@ -50,7 +67,6 @@ lazy val clientSettings: Seq[Setting[?]] = Seq(
 )
 
 lazy val defaultClientSettings: Seq[Setting[?]] = Seq(
-  name                :=  ghProject + "-default",
   description         := "Default scala client for the Guardian's Content API",
   libraryDependencies ++= clientDeps ++ defaultClientDeps,
   console / initialCommands   := """

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ lazy val catsEffectClient = (project in file("client-cats-effect"))
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "2.13.0",
       "org.typelevel" %% "cats-effect" % "3.7.0",
+      "org.typelevel" %% "log4cats-slf4j"   % "2.8.0",
       "co.fs2" %% "fs2-core" % "3.13.0",
       "com.madgag" %% "bin-packing" % "2.0.0",
       "org.typelevel" %% "weaver-cats" % "0.13.0" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,10 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 val ghProject = "content-api-client"
 
 lazy val root = (project in file("."))
-  .aggregate(client, defaultClient, firehoseClient)
+  .aggregate(client, defaultClient, catsEffectClient, firehoseClient)
   .settings(
     publish / skip := true,
-    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+    // releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq(
       checkSnapshotDependencies,
       inquireVersions,
@@ -30,6 +30,24 @@ lazy val client = (project in file("client"))
 lazy val defaultClient = (project in file("client-default"))
   .dependsOn(client)
   .settings(artifactProductionSettings, defaultClientSettings)
+  .settings(
+    name                :=  ghProject + "-default"
+  )
+
+lazy val catsEffectClient = (project in file("client-cats-effect"))
+  .dependsOn(client, defaultClient % "compile->compile;test->test")
+  .settings(artifactProductionSettings, defaultClientSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-core" % "2.13.0",
+      "org.typelevel" %% "cats-effect" % "3.7.1",
+      "org.typelevel" %% "log4cats-slf4j"   % "2.8.0",
+      "co.fs2" %% "fs2-core" % "3.13.0",
+      "com.madgag" %% "bin-packing" % "3.0.0",
+      "org.typelevel" %% "weaver-cats" % "0.13.0" % Test
+    ),
+    name                :=  ghProject + "-cats-effect"
+  )
 
 lazy val firehoseClient = (project in file("firehose-client"))
   .settings(artifactProductionSettings).settings(
@@ -67,7 +85,6 @@ lazy val clientSettings: Seq[Setting[?]] = Seq(
 )
 
 lazy val defaultClientSettings: Seq[Setting[?]] = Seq(
-  name                :=  ghProject + "-default",
   description         := "Default scala client for the Guardian's Content API",
   libraryDependencies ++= clientDeps ++ defaultClientDeps,
   console / initialCommands   := """

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/IOCapiClient.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/IOCapiClient.scala
@@ -1,0 +1,73 @@
+package com.gu.contentapi.client.catseffect
+
+import cats.effect.IO
+import com.gu.contentapi.client.Decoder.PageableResponseDecoder
+import com.gu.contentapi.client.catseffect.Retrying.retry
+import com.gu.contentapi.client.catseffect.bulkqueries.BulkContentRequester
+import com.gu.contentapi.client.model.Direction.Next
+import com.gu.contentapi.client.model.{ContentApiError, ContentApiQuery, PaginatedApiQuery, SearchQuery}
+import com.gu.contentapi.client.{ContentApiClient, Decoder, GuardianContentClient}
+import com.twitter.scrooge.ThriftStruct
+import fs2.Stream.unfoldChunkLoopEval
+import fs2.{Chunk, Stream}
+
+import java.net.URI
+import java.net.http.HttpClient.Version.HTTP_2
+import java.net.http.HttpResponse.BodyHandlers.discarding
+import java.net.http.{HttpClient, HttpRequest}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.jdk.OptionConverters._
+import scala.util.control.Exception.noCatch.desc
+
+/** Originally copied from code at
+  * https://github.com/guardian/word-usage/blob/7587abcdc06738414655bd05ea5ee4854a4b3925/src/main/scala/com/gu/words/capi/IOCapiClient.scala#L19
+  */
+class IOCapiClient private (
+    protected[catseffect] val underlyingClient: ContentApiClient,
+    rateLimiter: TokenBucket
+)(implicit
+    ec: ExecutionContext
+) {
+
+  def getResponse[Resp <: ThriftStruct: Decoder](query: ContentApiQuery[Resp]): IO[Resp] =
+    retry( // probably use cats-retry once on Scala 3...
+      execute(query),
+      desc = query.getClass.getSimpleName,
+      detail = query.getUrl(""),
+      errorAnalyzer = { case cae: ContentApiError => s"HTTP ${cae.httpStatus} - ${cae.errorResponse}" },
+      retries = 5
+    )
+
+  def paginatedStream[R <: ThriftStruct, E, T](
+      query: PaginatedApiQuery[R, E]
+  )(implicit prd: PageableResponseDecoder[R, T]): Stream[IO, T] =
+    unfoldChunkLoopEval(query)(getResponse(_).map { resp =>
+      (Chunk.from[T](prd.elements(resp).toList), query.followingQueryGiven(resp, Next))
+    })
+
+  def bulkContentRequestsBasedOn(baseQuery: SearchQuery) = BulkContentRequester(this, baseQuery)
+
+  private def execute[Resp <: ThriftStruct: Decoder](query: ContentApiQuery[Resp]): IO[Resp] =
+    rateLimiter.enforceWithDelay >> IO.fromFuture(IO(underlyingClient.getResponse(query)))
+}
+
+object IOCapiClient {
+
+  private val httpClientForTestingRateLimit: HttpClient = HttpClient.newBuilder.version(HTTP_2).build()
+
+  private def getPerMinuteQuotaFor(apiKey: String): Int = httpClientForTestingRateLimit
+    .send(HttpRequest.newBuilder(URI.create(s"https://content.guardianapis.com/?api-key=$apiKey")).GET().build(), discarding)
+    .headers().firstValueAsLong("x-ratelimit-limit-minute").toScala.get.toInt
+
+  private def createRateLimiterAppropriateTo(apiKey: String): IO[TokenBucket] = {
+    val minuteQuota = getPerMinuteQuotaFor(apiKey)
+    IO.println(s"CAPI Quota per min: $minuteQuota") >>
+      TokenBucket.create(minuteQuota, minuteQuota / 60, 1.second)
+  }
+
+  def from(apiKey: String)(implicit ec: ExecutionContext): IO[IOCapiClient] = for {
+    rateLimiter <- createRateLimiterAppropriateTo(apiKey)
+  } yield new IOCapiClient(new GuardianContentClient(apiKey), rateLimiter)
+
+}

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/IOCapiClient.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/IOCapiClient.scala
@@ -10,6 +10,7 @@ import com.gu.contentapi.client.{ContentApiClient, Decoder, GuardianContentClien
 import com.twitter.scrooge.ThriftStruct
 import fs2.Stream.unfoldChunkLoopEval
 import fs2.{Chunk, Stream}
+import org.typelevel.log4cats.{LoggerFactory, SelfAwareStructuredLogger}
 
 import java.net.URI
 import java.net.http.HttpClient.Version.HTTP_2
@@ -18,7 +19,6 @@ import java.net.http.{HttpClient, HttpRequest}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.jdk.OptionConverters._
-import scala.util.control.Exception.noCatch.desc
 
 /** Originally copied from code at
   * https://github.com/guardian/word-usage/blob/7587abcdc06738414655bd05ea5ee4854a4b3925/src/main/scala/com/gu/words/capi/IOCapiClient.scala#L19
@@ -27,11 +27,13 @@ class IOCapiClient private (
     protected[catseffect] val underlyingClient: ContentApiClient,
     rateLimiter: TokenBucket
 )(implicit
-    ec: ExecutionContext
+    ec: ExecutionContext,
+    logging: LoggerFactory[IO]
 ) {
+  implicit val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
 
   def getResponse[Resp <: ThriftStruct: Decoder](query: ContentApiQuery[Resp]): IO[Resp] =
-    retry( // probably use cats-retry once on Scala 3...
+    retry(
       execute(query),
       desc = query.getClass.getSimpleName,
       detail = query.getUrl(""),
@@ -66,7 +68,7 @@ object IOCapiClient {
       TokenBucket.create(minuteQuota, minuteQuota / 60, 1.second)
   }
 
-  def from(apiKey: String)(implicit ec: ExecutionContext): IO[IOCapiClient] = for {
+  def from(apiKey: String)(implicit ec: ExecutionContext, loggerFactory: LoggerFactory[IO]): IO[IOCapiClient] = for {
     rateLimiter <- createRateLimiterAppropriateTo(apiKey)
   } yield new IOCapiClient(new GuardianContentClient(apiKey), rateLimiter)
 

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/IOCapiClient.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/IOCapiClient.scala
@@ -1,0 +1,78 @@
+package com.gu.contentapi.client.catseffect
+
+import cats.effect.IO
+import com.gu.contentapi.client.Decoder.PageableResponseDecoder
+import com.gu.contentapi.client.catseffect.Retrying.{ErrorAnalysis, retry}
+import com.gu.contentapi.client.catseffect.bulkqueries.BulkContentRequester
+import com.gu.contentapi.client.model.Direction.Next
+import com.gu.contentapi.client.model.HttpResponse.failedButMaybeRecoverableCodes
+import com.gu.contentapi.client.model.{ContentApiError, ContentApiQuery, PaginatedApiQuery, SearchQuery}
+import com.gu.contentapi.client.{ContentApiClient, Decoder, GuardianContentClient}
+import com.twitter.scrooge.ThriftStruct
+import fs2.Stream.unfoldChunkLoopEval
+import fs2.{Chunk, Stream}
+import org.typelevel.log4cats.{LoggerFactory, SelfAwareStructuredLogger}
+
+import java.net.URI
+import java.net.http.HttpClient.Version.HTTP_2
+import java.net.http.HttpResponse.BodyHandlers.discarding
+import java.net.http.{HttpClient, HttpRequest}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.jdk.OptionConverters._
+
+/** Originally copied from code at
+  * https://github.com/guardian/word-usage/blob/7587abcdc06738414655bd05ea5ee4854a4b3925/src/main/scala/com/gu/words/capi/IOCapiClient.scala#L19
+  */
+class IOCapiClient private (
+    protected[catseffect] val underlyingClient: ContentApiClient,
+    rateLimiter: TokenBucket
+)(implicit
+    ec: ExecutionContext,
+    logging: LoggerFactory[IO]
+) {
+  implicit val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
+
+  def getResponse[Resp <: ThriftStruct: Decoder](query: ContentApiQuery[Resp]): IO[Resp] =
+    retry(
+      execute(query),
+      desc = query.getClass.getSimpleName,
+      detail = query.getUrl(""),
+      errorAnalyzer = { case cae: ContentApiError => ErrorAnalysis(
+        maybeRecoverable = failedButMaybeRecoverableCodes.contains(cae.httpStatus),
+        s"HTTP ${cae.httpStatus} - ${cae.errorResponse}") },
+      retries = 5
+    )
+
+  def paginatedStream[R <: ThriftStruct, E, T](
+      query: PaginatedApiQuery[R, E]
+  )(implicit prd: PageableResponseDecoder[R, T]): Stream[IO, T] =
+    unfoldChunkLoopEval(query)(getResponse(_).map { resp =>
+      (Chunk.from[T](prd.elements(resp).toList), query.followingQueryGiven(resp, Next))
+    })
+
+  def bulkContentRequestsBasedOn(baseQuery: SearchQuery) = BulkContentRequester(this, baseQuery)
+
+  private def execute[Resp <: ThriftStruct: Decoder](query: ContentApiQuery[Resp]): IO[Resp] =
+    rateLimiter.enforceWithDelay >> IO.fromFuture(IO(underlyingClient.getResponse(query)))
+}
+
+object IOCapiClient {
+
+  private val httpClientForTestingRateLimit: HttpClient = HttpClient.newBuilder.version(HTTP_2).build()
+
+  private def getPerMinuteQuotaFor(apiKey: String): Int = httpClientForTestingRateLimit
+    .send(HttpRequest.newBuilder(URI.create(s"https://content.guardianapis.com/?api-key=$apiKey")).GET().build(), discarding)
+    .headers().firstValueAsLong("x-ratelimit-limit-minute").toScala.get.toInt
+
+  private def createRateLimiterAppropriateTo(apiKey: String): IO[TokenBucket] = {
+    val minuteQuota = getPerMinuteQuotaFor(apiKey)
+    IO.println(s"CAPI Quota per min: $minuteQuota") >>
+      TokenBucket.create(minuteQuota, minuteQuota / 60, 1.second)
+  }
+
+  def from(apiKey: String)(implicit ec: ExecutionContext, loggerFactory: LoggerFactory[IO]): IO[IOCapiClient] = for {
+    rateLimiter <- createRateLimiterAppropriateTo(apiKey)
+  } yield new IOCapiClient(new GuardianContentClient(apiKey), rateLimiter)
+
+}

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/Retrying.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/Retrying.scala
@@ -1,0 +1,46 @@
+package com.gu.contentapi.client.catseffect
+
+import cats.effect.IO
+import cats.effect.std.Random
+
+import scala.concurrent.duration._
+
+object Retrying {
+
+  /** Log:
+    *   - Initial failure
+    *   - Final failure
+    *   - Success after a failure
+    *
+    * To reduce log noise, don't log failures after initial failure, unless it was the last attempt.
+    */
+  def retry[A](
+      io: IO[A],
+      desc: String,
+      detail: String,
+      errorAnalyzer: PartialFunction[Throwable, String],
+      retries: Int
+  )(implicit random: Random[IO]): IO[A] =  io
+
+//  {
+//    def loop(n: Int): IO[A] =
+//      io.flatTap(_ =>
+//        IO.whenA(n > 0)(IO(logger.info(s"$desc: Made ${n + 1}/$retries attempts before success")))
+//      ).handleErrorWith { e =>
+//        if (n >= retries)
+//          IO(logger.error(s"$desc: All $retries retries failed ($detail): ${errorAnalyzer(e)}", e)) >>
+//            IO.raiseError(e)
+//        else
+//          for {
+//            _ <- IO.whenA(n == 0)(
+//              IO(logger.warn(s"$desc: Initial attempt (out of $retries) failed: ${errorAnalyzer(e)}", e))
+//            )
+//            baseWaitingTime = 100L << n
+//            jitter <- random.betweenLong(0L, baseWaitingTime)
+//            result <- IO.sleep((baseWaitingTime + jitter).millis) >> loop(n + 1)
+//          } yield result
+//      }
+//
+//    loop(0)
+//  }
+}

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/Retrying.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/Retrying.scala
@@ -2,45 +2,48 @@ package com.gu.contentapi.client.catseffect
 
 import cats.effect.IO
 import cats.effect.std.Random
+import org.typelevel.log4cats.SelfAwareStructuredLogger
 
 import scala.concurrent.duration._
 
 object Retrying {
 
   /** Log:
-    *   - Initial failure
-    *   - Final failure
-    *   - Success after a failure
-    *
-    * To reduce log noise, don't log failures after initial failure, unless it was the last attempt.
-    */
+   *   - Initial failure
+   *   - Final failure
+   *   - Success after a failure
+   *
+   * To reduce log noise, don't log failures after initial failure, unless it was the last attempt.
+   */
   def retry[A](
-      io: IO[A],
-      desc: String,
-      detail: String,
-      errorAnalyzer: PartialFunction[Throwable, String],
-      retries: Int
-  )(implicit random: Random[IO]): IO[A] =  io
+    io: IO[A],
+    desc: String,
+    detail: String,
+    errorAnalyzer: PartialFunction[Throwable, String],
+    retries: Int
+  )(implicit random: Random[IO], l: SelfAwareStructuredLogger[IO]): IO[A] = for {
+    seriesId <- random.nextLong
+    result <- {
+      val logger = l.withModifiedString(s => s"$desc: $s").addContext(Map("retry.series.id" -> seriesId.toString))
 
-//  {
-//    def loop(n: Int): IO[A] =
-//      io.flatTap(_ =>
-//        IO.whenA(n > 0)(IO(logger.info(s"$desc: Made ${n + 1}/$retries attempts before success")))
-//      ).handleErrorWith { e =>
-//        if (n >= retries)
-//          IO(logger.error(s"$desc: All $retries retries failed ($detail): ${errorAnalyzer(e)}", e)) >>
-//            IO.raiseError(e)
-//        else
-//          for {
-//            _ <- IO.whenA(n == 0)(
-//              IO(logger.warn(s"$desc: Initial attempt (out of $retries) failed: ${errorAnalyzer(e)}", e))
-//            )
-//            baseWaitingTime = 100L << n
-//            jitter <- random.betweenLong(0L, baseWaitingTime)
-//            result <- IO.sleep((baseWaitingTime + jitter).millis) >> loop(n + 1)
-//          } yield result
-//      }
-//
-//    loop(0)
-//  }
+      def loop(n: Int): IO[A] =
+        io.flatTap(_ =>
+          IO.whenA(n > 0)(logger.info(s"Made ${n + 1}/$retries attempts before success"))
+        ).handleErrorWith { e =>
+          if (n >= retries)
+            logger.error(e)(s"All $retries retries failed ($detail): ${errorAnalyzer(e)}") >>
+              IO.raiseError(e)
+          else
+            for {
+              _ <- IO.whenA(n == 0)(logger.warn(e)(s"Initial attempt (out of $retries) failed: ${errorAnalyzer(e)}"))
+              baseWaitingTime = 100L << n
+              jitter <- random.betweenLong(0L, baseWaitingTime)
+              result <- IO.sleep((baseWaitingTime + jitter).millis) >> loop(n + 1)
+            } yield result
+        }
+
+      logger.info("Does this work") >> loop(0)
+    }
+  } yield result
+
 }

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/Retrying.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/Retrying.scala
@@ -1,0 +1,51 @@
+package com.gu.contentapi.client.catseffect
+
+import cats.effect.IO
+import cats.effect.std.Random
+import org.typelevel.log4cats.SelfAwareStructuredLogger
+
+import scala.concurrent.duration._
+
+object Retrying {
+  case class ErrorAnalysis(maybeRecoverable: Boolean, text: String)
+  /** Log:
+   *   - Initial failure
+   *   - Final failure
+   *   - Success after a failure
+   *
+   * To reduce log noise, don't log failures after initial failure, unless it was the last attempt.
+   */
+  def retry[A](
+    io: IO[A],
+    desc: String,
+    detail: String,
+    errorAnalyzer: PartialFunction[Throwable, ErrorAnalysis],
+    retries: Int
+  )(implicit random: Random[IO], l: SelfAwareStructuredLogger[IO]): IO[A] = for {
+    seriesId <- random.nextLong
+    result <- {
+      val logger = l.withModifiedString(s => s"$desc: $s").addContext(Map("retry.series.id" -> seriesId.toString))
+
+      def loop(n: Int): IO[A] =
+        io.flatTap(_ =>
+          IO.whenA(n > 0)(logger.info(s"Made ${n + 1}/$retries attempts before success"))
+        ).handleErrorWith { e =>
+          val errorAnalysis = errorAnalyzer.lift(e)
+          def finish(reason: String) = {
+            logger.error(e)(s"$reason ($detail): $errorAnalysis") >> IO.raiseError(e)
+          }
+
+          if (n >= retries) finish(s"All $retries retries failed")
+          else if (!errorAnalysis.exists(_.maybeRecoverable)) finish("Irrecoverable failure") else for {
+            _ <- IO.whenA(n == 0)(logger.warn(e)(s"Initial attempt (out of $retries) had a recoverable failure: $errorAnalysis"))
+            baseWaitingTime = 100L << n
+            jitter <- random.betweenLong(0L, baseWaitingTime)
+            result <- IO.sleep((baseWaitingTime + jitter).millis) >> loop(n + 1)
+          } yield result
+        }
+
+      loop(0)
+    }
+  } yield result
+
+}

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/TokenBucket.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/TokenBucket.scala
@@ -1,0 +1,37 @@
+package com.gu.contentapi.client.catseffect
+
+import cats.effect.std.Semaphore
+import cats.effect.{FiberIO, IO}
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Token buckets can be used for rate-limiting - so we can throttle the rate of our requests to the
+ * CAPI service.
+ *
+ * [[https://en.wikipedia.org/wiki/Token_bucket]]
+ */
+final class TokenBucket private (
+    sem: Semaphore[IO],
+    capacity: Long,
+    refillAmount: Long,
+    refillPeriod: FiniteDuration
+) {
+  def enforceWithDelay: IO[Unit] = sem.acquire
+
+  private val refillLoop: IO[Unit] =
+    (IO.sleep(refillPeriod) >> sem.available.flatMap { available =>
+      val maximumAddablePermits = (capacity - available).max(0)
+      sem.releaseN(refillAmount min maximumAddablePermits)
+    }).foreverM
+
+  private def start: IO[FiberIO[Unit]] = refillLoop.start
+}
+
+object TokenBucket {
+  def create(capacity: Int, refillAmount: Int, refillPeriod: FiniteDuration): IO[TokenBucket] = for {
+    sem <- Semaphore[IO](capacity.toLong)
+    tb = new TokenBucket(sem, capacity.toLong, refillAmount.toLong, refillPeriod)
+    _ <- tb.start
+  } yield tb
+}

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/TokenBucket.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/TokenBucket.scala
@@ -1,0 +1,34 @@
+package com.gu.contentapi.client.catseffect
+
+import cats.effect.std.Semaphore
+import cats.effect.{FiberIO, IO}
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Token buckets can be used for rate-limiting - so we can throttle the rate of our requests to the
+ * CAPI service.
+ *
+ * [[https://en.wikipedia.org/wiki/Token_bucket]]
+ */
+final class TokenBucket private (
+    sem: Semaphore[IO],
+    capacity: Long,
+    refillAmount: Long,
+    refillPeriod: FiniteDuration
+) {
+  def enforceWithDelay: IO[Unit] = sem.acquire
+
+  private val refillLoop: IO[Unit] =
+    (IO.sleep(refillPeriod) >> sem.releaseN(refillAmount.min(capacity))).foreverM
+
+  private def start: IO[FiberIO[Unit]] = refillLoop.start
+}
+
+object TokenBucket {
+  def create(capacity: Int, refillAmount: Int, refillPeriod: FiniteDuration): IO[TokenBucket] = for {
+    sem <- Semaphore[IO](capacity.toLong)
+    tb = new TokenBucket(sem, capacity.toLong, refillAmount.toLong, refillPeriod)
+    _ <- tb.start
+  } yield tb
+}

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/bulkqueries/BulkContentRequester.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/bulkqueries/BulkContentRequester.scala
@@ -1,0 +1,67 @@
+package com.gu.contentapi.client.catseffect.bulkqueries
+
+import cats.effect.IO
+import com.gu.contentapi.client.catseffect.IOCapiClient
+import com.gu.contentapi.client.catseffect.bulkqueries.RequestSizing.Calculated.{availableUrlSpaceForIdsGiven, capiIdSizer}
+import com.gu.contentapi.client.catseffect.bulkqueries.RequestSizing.MaxItemsAllowedInIdsParameter
+import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.model.{CapiId, SearchQuery}
+import com.madgag.algo.packing.binpacking.BinPacking.Size.CardinalityConstrained
+import com.madgag.algo.packing.binpacking.OfflineAlgorithm.{FFD, dotProductFFD}
+import com.madgag.algo.packing.binpacking._
+import fs2.Stream
+import fs2.Stream.emits
+import spire.implicits._
+
+/**
+ * This class provides safe bulk-requesting of `Content` by `CapiId`.
+ *
+ * When requesting an arbitrary number of `CapiId`s, a single request can easily exceed one of two hard limits:
+ *
+ *   - the url can grow larger than the 4096 character '''url-size limit''' imposed by the Content API HTTP endpoints,
+ *     and get a [[https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/414 HTTP 414 URI Too Long]] error
+ *     response.
+ *   - the ids parameter itself has a '''max-ids-per-request limit''' of 50 CAPI ids.
+ *
+ * This class works out how much url-space is available, and [[https://github.com/rtyley/bin-packing packs]] the
+ * requested `CapiId`s into the lowest-possible number of requests, respecting both the url-size and
+ * max-ids-per-request limits (sometimes, CAPI ids _can_ be short enough to fit more than 50 into the request url -
+ * exceeding the max-ids-per-request limit but not the url-size limit).
+ *
+ * Creating an instance of `BulkContentRequester` performs some initial space calculations. You can retain the
+ * instance and then use it over and over again with different sets of CAPI ids.
+ */
+class BulkContentRequester private(client: IOCapiClient, baseQuery: SearchQuery) {
+
+  private val packer: Packer[CapiId] = Packer[CardinalityConstrained](
+    binSize = CardinalityConstrained(
+      size = availableUrlSpaceForIdsGiven(client.underlyingClient, baseQuery),
+      cardinality = MaxItemsAllowedInIdsParameter
+    ),
+    dotProductFFD(CardinalityConstrained.coordSpace)
+  ).using[CapiId](capiId => CardinalityConstrained.item(capiIdSizer(capiId)))
+
+  /** @param capiIds
+    *   The set of CAPI-ids can be large - it is not constrained by URL-length
+    */
+  def contentStream(capiIds: Set[CapiId]): Stream[IO, Content] =
+    emits(pack(capiIds).toSeq).covary[IO].parEvalMapUnordered(8)(bulkGet).flatMap(emits)
+
+  /** @return
+   *   CAPI-ids grouped so that the query will not exceed either the url-size or max-ids-per-request limits
+   */
+  private def pack(capiIds: Set[CapiId]): Set[Set[CapiId]] = capiIds.packWith(packer)
+
+  /** Note: This method does not check any size limits - if the set of `CapiId`s is too large, the
+   * Content API service will return an HTTP error response.
+   */
+  private def bulkGet(capiIds: Set[CapiId]): IO[Seq[Content]] =
+    client.getResponse(baseQuery.withIds(capiIds)).map(_.results.toSeq)
+}
+
+object BulkContentRequester {
+  def apply(client: IOCapiClient, baseQuery: SearchQuery): BulkContentRequester = new BulkContentRequester(
+    client,
+    baseQuery.pageSize(MaxItemsAllowedInIdsParameter) // default page-size is 10, too small - we can pack more CAPI ids than that into a request
+  )
+}

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/bulkqueries/BulkContentRequester.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/bulkqueries/BulkContentRequester.scala
@@ -1,0 +1,66 @@
+package com.gu.contentapi.client.catseffect.bulkqueries
+
+import cats.effect.IO
+import com.gu.contentapi.client.catseffect.IOCapiClient
+import com.gu.contentapi.client.catseffect.bulkqueries.RequestSizing.Calculated.{availableUrlSpaceForIdsGiven, capiIdSizer}
+import com.gu.contentapi.client.catseffect.bulkqueries.RequestSizing.MaxItemsAllowedInIdsParameter
+import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.model.{CapiId, SearchQuery}
+import com.madgag.algo.packing.binpacking.BinPacking.Size.CardinalityConstrained
+import com.madgag.algo.packing.binpacking.OfflineAlgorithm.FFD
+import com.madgag.algo.packing.binpacking._
+import fs2.Stream
+import fs2.Stream.emits
+
+/**
+ * This class provides safe bulk-requesting of `Content` by `CapiId`.
+ *
+ * When requesting an arbitrary number of `CapiId`s, a single request can easily exceed one of two hard limits:
+ *
+ *   - the url can grow larger than the 4096 character '''url-size limit''' imposed by the Content API HTTP endpoints,
+ *     and get a [[https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/414 HTTP 414 URI Too Long]] error
+ *     response.
+ *   - the ids parameter itself has a '''max-ids-per-request limit''' of 50 CAPI ids.
+ *
+ * This class works out how much url-space is available, and [[https://github.com/rtyley/bin-packing packs]] the
+ * requested `CapiId`s into the lowest-possible number of requests, respecting both the url-size and
+ * max-ids-per-request limits (sometimes, CAPI ids _can_ be short enough to fit more than 50 into the request url -
+ * exceeding the max-ids-per-request limit but not the url-size limit).
+ *
+ * Creating an instance of `BulkContentRequester` performs some initial space calculations. You can retain the
+ * instance and then use it over and over again with different sets of CAPI ids.
+ */
+class BulkContentRequester private(client: IOCapiClient, baseQuery: SearchQuery) {
+
+  private val packer: Packer[CapiId, CardinalityConstrained] = Packer(Setup(
+    binSize = CardinalityConstrained(
+      size = availableUrlSpaceForIdsGiven(client.underlyingClient, baseQuery),
+      cardinality = MaxItemsAllowedInIdsParameter
+    ),
+    sizer = capiId => CardinalityConstrained.item(capiIdSizer(capiId))
+  ), FFD)
+
+  /** @param capiIds
+    *   The set of CAPI-ids can be large - it is not constrained by URL-length
+    */
+  def contentStream(capiIds: Set[CapiId]): Stream[IO, Content] =
+    emits(pack(capiIds).toSeq).parEvalMapUnorderedUnbounded(bulkGet).flatMap(emits)
+
+  /** @return
+   *   CAPI-ids grouped so that the query will not exceed either the url-size or max-ids-per-request limits
+   */
+  private def pack(capiIds: Set[CapiId]): Set[Set[CapiId]] = capiIds.packWith(packer)
+
+  /** Note: This method does not check any size limits - if the set of `CapiId`s is too large, the
+   * Content API service will return an HTTP error response.
+   */
+  private def bulkGet(capiIds: Set[CapiId]): IO[Seq[Content]] =
+    client.getResponse(baseQuery.withIds(capiIds)).map(_.results.toSeq)
+}
+
+object BulkContentRequester {
+  def apply(client: IOCapiClient, baseQuery: SearchQuery): BulkContentRequester = new BulkContentRequester(
+    client,
+    baseQuery.pageSize(MaxItemsAllowedInIdsParameter) // default page-size is 10, too small - we can pack more CAPI ids than that into a request
+  )
+}

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/bulkqueries/RequestSizing.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/bulkqueries/RequestSizing.scala
@@ -1,0 +1,95 @@
+package com.gu.contentapi.client.catseffect.bulkqueries
+
+import com.gu.contentapi.client.ContentApiClient
+import com.gu.contentapi.client.model.{CapiId, SearchQuery}
+
+import java.net.{URI, URLEncoder}
+import java.nio.charset.StandardCharsets.UTF_8
+import BulkContentRequester._
+import com.gu.contentapi.client.catseffect.bulkqueries.RequestSizing.Calculated.capiIdSizer
+import com.gu.contentapi.client.model.SearchQuery.IdSeparator
+
+/** In order to send bulk-queries that are *not* too big (ie no request bigger than
+  * [[RequestSizing.MaxCapiUriLength]]), we need to know how much space in the
+  * url is:
+  *
+  *   - left available in the url for CAPI-ids (derived from how much is already used)
+  *   - consumed by each CAPI-id that's added
+  *
+  * Available space can be determined practically using the actual ContentApiClient to construct the url, and
+  * we can then verify that figure by calculating a few more urls.
+  */
+trait RequestSizing {
+
+  /** @return
+    *  the length of the part of the url that counts towards the [[RequestSizing.MaxCapiUriLength]] - ie
+    *  the path & query params, without "https://content.guardianapis.com/"
+    */
+  def urlLengthFor(ids: Set[CapiId]): Int
+}
+
+object RequestSizing {
+  /**
+   * This limit includes the path, starting with the slash, the query parameters, and the separating '?'.
+   * It does not include the protocol, or domain.
+   */
+  val MaxCapiUriLength = 4096
+
+  /**
+   * Can't ask for more than 50 CAPI ids at a time - the Content API will error:
+   * "IDs parameter cannot contain more than 50 items"
+   *
+   * https://github.com/guardian/content-api/blob/dc64e5fe94bcd7e2a03cdb6d5cf5db3b415fbee4/concierge/src/main/scala/com.gu.contentapi.concierge/parameters/Parameters.scala#L592
+   */
+  val MaxItemsAllowedInIdsParameter = 50
+
+  def urlEncodedLengthOf(s: String): Int = URLEncoder.encode(s, UTF_8).length
+
+  /** Calculates a bulk-query's url length by getting the actual ContentApiClient to construct the url - this
+    * is the actual url that will get sent, so the reported length is truthful.
+    */
+  class Practical(contentApiClient: ContentApiClient, baseQuery: SearchQuery) extends RequestSizing {
+    override def urlLengthFor(ids: Set[CapiId]): Int = {
+      val uri = URI.create(contentApiClient.url(baseQuery.withIds(ids)))
+      uri.getRawPath.length + 1 + uri.getRawQuery.length
+    }
+  }
+
+  /** Calculates a bulk-query's url length, based on how much space is taken by the individual CAPI-ids, and
+    * exactly how much space is taken up by the rest of the query parameters and path.
+    */
+  case class Calculated(baseUrlSize: Int) extends RequestSizing {
+    override def urlLengthFor(ids: Set[CapiId]): Int = {
+      require(ids.nonEmpty)
+      baseUrlSize + ids.toSeq.map(capiIdSizer).sum
+    }
+
+    val availableUrlSpaceForIds: Int = MaxCapiUriLength - baseUrlSize
+  }
+
+  object Calculated {
+    private val UrlEncodedLengthOfIdSeparator: Int = urlEncodedLengthOf(IdSeparator)
+    val capiIdSizer: CapiId => Int = capiId => urlEncodedLengthOf(capiId.value) + UrlEncodedLengthOfIdSeparator
+
+    private val sampleCapiIds = Seq(
+      "us-news/live/2021/jan/26/joe-biden-donald-trump-impeachment-kamala-harris-nancy-pelosi-covid-coronavirus-live-updates",
+      "us-news/live/2021/jan/29/joe-biden-donald-trump-impeachment-covid-coronavirus-nancy-pelosi-kamala-harris-live-updates",
+      "stage/2019/sep/03/standup-comedy-john-oliver-edinburgh-fringe-festival"
+    ).map(CapiId(_))
+
+    def basedOff(reference: RequestSizing): Calculated = {
+      val trialCapiId = sampleCapiIds.head
+      val calculated = Calculated(reference.urlLengthFor(Set(trialCapiId)) - capiIdSizer(trialCapiId))
+      sampleCapiIds.toSet.subsets().filter(_.nonEmpty).foreach { s =>
+        val calcSize = calculated.urlLengthFor(s)
+        val refSize = reference.urlLengthFor(s)
+        require(calcSize == refSize, s"Differing size: $calcSize vs $refSize for $s")
+      }
+      calculated
+    }
+
+    def availableUrlSpaceForIdsGiven(contentApiClient: ContentApiClient, baseQuery: SearchQuery): Int =
+      Calculated.basedOff(new Practical(contentApiClient, baseQuery)).availableUrlSpaceForIds
+  }
+
+}

--- a/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/bulkqueries/RequestSizing.scala
+++ b/client-cats-effect/src/main/scala/com/gu/contentapi/client/catseffect/bulkqueries/RequestSizing.scala
@@ -1,0 +1,94 @@
+package com.gu.contentapi.client.catseffect.bulkqueries
+
+import com.gu.contentapi.client.ContentApiClient
+import com.gu.contentapi.client.catseffect.bulkqueries.RequestSizing.Calculated.capiIdSizer
+import com.gu.contentapi.client.model.SearchQuery.IdSeparator
+import com.gu.contentapi.client.model.{CapiId, SearchQuery}
+import com.gu.contentapi.client.utils.QueryStringParams
+
+import java.net.URI
+
+/** In order to send bulk-queries that are *not* too big (ie no request bigger than
+  * [[RequestSizing.MaxCapiUriLength]]), we need to know how much space in the
+  * url is:
+  *
+  *   - left available in the url for CAPI-ids (derived from how much is already used)
+  *   - consumed by each CAPI-id that's added
+  *
+  * Available space can be determined practically using the actual ContentApiClient to construct the url, and
+  * we can then verify that figure by calculating a few more urls.
+  */
+trait RequestSizing {
+
+  /** @return
+    *  the length of the part of the url that counts towards the [[RequestSizing.MaxCapiUriLength]] - ie
+    *  the path & query params, without "https://content.guardianapis.com/"
+    */
+  def urlLengthFor(ids: Set[CapiId]): Int
+}
+
+object RequestSizing {
+  /**
+   * This limit includes the path, starting with the slash, the query parameters, and the separating '?'.
+   * It does not include the protocol, or domain.
+   */
+  val MaxCapiUriLength = 4096
+
+  /**
+   * Can't ask for more than 50 CAPI ids at a time - the Content API will error:
+   * "IDs parameter cannot contain more than 50 items"
+   *
+   * https://github.com/guardian/content-api/blob/dc64e5fe94bcd7e2a03cdb6d5cf5db3b415fbee4/concierge/src/main/scala/com.gu.contentapi.concierge/parameters/Parameters.scala#L592
+   */
+  val MaxItemsAllowedInIdsParameter = 50
+
+  /** Calculates a bulk-query's url length by getting the actual ContentApiClient to construct the url - this
+    * is the actual url that will get sent, so the reported length is truthful.
+    */
+  class Practical(contentApiClient: ContentApiClient, baseQuery: SearchQuery) extends RequestSizing {
+    override def urlLengthFor(ids: Set[CapiId]): Int = {
+      val uri = URI.create(contentApiClient.url(baseQuery.withIds(ids)))
+      uri.getRawPath.length + 1 + uri.getRawQuery.length
+    }
+  }
+
+  /** Calculates a bulk-query's url length, based on how much space is taken by the individual CAPI-ids, and
+    * exactly how much space is taken up by the rest of the query parameters and path.
+    */
+  case class Calculated(baseUrlSize: Int) extends RequestSizing {
+    override def urlLengthFor(ids: Set[CapiId]): Int = {
+      require(ids.nonEmpty)
+      baseUrlSize + ids.toSeq.map(capiIdSizer).sum
+    }
+
+    val availableUrlSpaceForIds: Int = MaxCapiUriLength - baseUrlSize
+  }
+
+  object Calculated {
+    def urlEncodedLengthOf(s: String): Int = QueryStringParams.encodeParameter(s).length
+
+    private val UrlEncodedLengthOfIdSeparator: Int = urlEncodedLengthOf(IdSeparator)
+    val capiIdSizer: CapiId => Int = capiId => urlEncodedLengthOf(capiId.value) + UrlEncodedLengthOfIdSeparator
+
+    private val sampleCapiIds = Seq(
+      "us-news/live/2021/jan/26/joe-biden-donald-trump-impeachment-kamala-harris-nancy-pelosi-covid-coronavirus-live-updates",
+      "us-news/live/2021/jan/29/joe-biden-donald-trump-impeachment-covid-coronavirus-nancy-pelosi-kamala-harris-live-updates",
+      "stage/2019/sep/03/standup-comedy-john-oliver-edinburgh-fringe-festival"
+    ).map(CapiId(_))
+
+    def basedOff(reference: RequestSizing): Calculated = {
+      val trialCapiId = sampleCapiIds.head
+      val calculated = Calculated(reference.urlLengthFor(Set(trialCapiId)) - capiIdSizer(trialCapiId))
+      sampleCapiIds.toSet.subsets().filter(_.nonEmpty).foreach { s =>
+        val calcSize = calculated.urlLengthFor(s)
+        val refSize = reference.urlLengthFor(s)
+        require(calcSize == refSize, s"Differing size: $calcSize vs $refSize for $s")
+      }
+      calculated
+    }
+
+    def availableUrlSpaceForIdsGiven(contentApiClient: ContentApiClient, baseQuery: SearchQuery): Int =
+      Calculated.basedOff(new Practical(contentApiClient, baseQuery)).availableUrlSpaceForIds
+  }
+
+}

--- a/client-cats-effect/src/test/scala/com/gu/contentapi/client/catseffect/bulkqueries/BulkContentRequesterTest.scala
+++ b/client-cats-effect/src/test/scala/com/gu/contentapi/client/catseffect/bulkqueries/BulkContentRequesterTest.scala
@@ -1,0 +1,36 @@
+package com.gu.contentapi.client.catseffect.bulkqueries
+
+import cats.effect.IO
+import com.gu.contentapi.client.GuardianContentClientTest
+import com.gu.contentapi.client.catseffect.IOCapiClient
+import com.gu.contentapi.client.model.SearchQuery
+import com.gu.contentapi.client.utils.CapiModelEnrichment.RichContent
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
+import weaver.SimpleIOSuite
+
+import java.time.LocalDate
+import java.time.ZoneOffset.UTC
+import java.time.temporal.ChronoUnit.DAYS
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.postfixOps
+
+object BulkContentRequesterTest extends SimpleIOSuite {
+
+  implicit val logging: LoggerFactory[IO] = Slf4jFactory.create[IO]
+
+  private val queryToObtainLotsOfTestIds: SearchQuery = {
+    val fixedMoment = LocalDate.of(2020,6,1).atStartOfDay(UTC).toInstant
+    SearchQuery().fromDate(fixedMoment).toDate(fixedMoment.plus(1, DAYS)).pageSize(50)
+  }
+
+  test("Should be able to fetch Content specified by an arbitrarily large number of CAPI ids") {
+    for {
+      client <- IOCapiClient.from(GuardianContentClientTest.apiKey)
+      lotsOfCapiIds <- client.paginatedStream(queryToObtainLotsOfTestIds).map(_.capiId).compile.to(Set)
+      _ = require(lotsOfCapiIds.size > 100)
+      bulkContentRequester = client.bulkContentRequestsBasedOn(SearchQuery().showTags("all"))
+      content <- bulkContentRequester.contentStream(lotsOfCapiIds).map(c => c.capiId -> c).compile.to(Map)
+    } yield expect(clue(content.size) == lotsOfCapiIds.size)
+  }
+}

--- a/client-cats-effect/src/test/scala/com/gu/contentapi/client/catseffect/bulkqueries/BulkContentRequesterTest.scala
+++ b/client-cats-effect/src/test/scala/com/gu/contentapi/client/catseffect/bulkqueries/BulkContentRequesterTest.scala
@@ -1,9 +1,12 @@
 package com.gu.contentapi.client.catseffect.bulkqueries
 
+import cats.effect.IO
+import com.gu.contentapi.client.GuardianContentClientTest
 import com.gu.contentapi.client.catseffect.IOCapiClient
 import com.gu.contentapi.client.model.SearchQuery
 import com.gu.contentapi.client.utils.CapiModelEnrichment.RichContent
-import com.gu.contentapi.client.{GuardianContentClientTest, SampleCapiIds}
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 import weaver.SimpleIOSuite
 
 import java.time.Instant
@@ -11,6 +14,8 @@ import java.time.temporal.ChronoUnit.DAYS
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object BulkContentRequesterTest extends SimpleIOSuite {
+
+  implicit val logging: LoggerFactory[IO] = Slf4jFactory.create[IO]
 
   val fixedMoment = Instant.parse("2020-06-01T00:00:00Z")
 

--- a/client-cats-effect/src/test/scala/com/gu/contentapi/client/catseffect/bulkqueries/BulkContentRequesterTest.scala
+++ b/client-cats-effect/src/test/scala/com/gu/contentapi/client/catseffect/bulkqueries/BulkContentRequesterTest.scala
@@ -1,0 +1,25 @@
+package com.gu.contentapi.client.catseffect.bulkqueries
+
+import com.gu.contentapi.client.catseffect.IOCapiClient
+import com.gu.contentapi.client.model.SearchQuery
+import com.gu.contentapi.client.utils.CapiModelEnrichment.RichContent
+import com.gu.contentapi.client.{GuardianContentClientTest, SampleCapiIds}
+import weaver.SimpleIOSuite
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit.DAYS
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object BulkContentRequesterTest extends SimpleIOSuite {
+
+  val fixedMoment = Instant.parse("2020-06-01T00:00:00Z")
+
+  test("Should be able to fetch Content specified by an arbitrarily large number of CAPI ids") {
+    for {
+      client <- IOCapiClient.from(GuardianContentClientTest.apiKey)
+      lotsOfCapiIds <- client.paginatedStream(SearchQuery().fromDate(fixedMoment).toDate(fixedMoment.plus(1, DAYS)).pageSize(50)).map(_.capiId).compile.to(Set)
+      bulkContentRequester = client.bulkContentRequestsBasedOn(SearchQuery().showTags("all"))
+      content <- bulkContentRequester.contentStream(lotsOfCapiIds).map(c => c.capiId -> c).compile.to(Map)
+    } yield expect(clue(content.size) == lotsOfCapiIds.size)
+  }
+}

--- a/client-cats-effect/src/test/scala/com/gu/contentapi/client/catseffect/bulkqueries/RequestSizingTest.scala
+++ b/client-cats-effect/src/test/scala/com/gu/contentapi/client/catseffect/bulkqueries/RequestSizingTest.scala
@@ -1,0 +1,71 @@
+package com.gu.contentapi.client.catseffect.bulkqueries
+
+import com.gu.contentapi.client.catseffect.bulkqueries.RequestSizing.{MaxCapiUriLength, Practical, urlEncodedLengthOf}
+import com.gu.contentapi.client.model.{CapiId, SearchQuery}
+import com.gu.contentapi.client.{ContentApiClient, GuardianContentClient, GuardianContentClientTest}
+import org.scalatest.Inspectors
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+import java.net.URI
+import java.net.http.HttpClient.Version.HTTP_2
+import java.net.http.HttpResponse.BodyHandlers.discarding
+import java.net.http.{HttpClient, HttpRequest}
+
+class RequestSizingTest extends AnyFlatSpec with should.Matchers with Inspectors {
+
+  private val baseQuery: SearchQuery = ContentApiClient.search.lang("en")
+  private val apiKey = GuardianContentClientTest.apiKey
+  private val client: ContentApiClient = new GuardianContentClient(apiKey)
+  private val expectedUrlSizeWithJustOneSingleCharCapiId = 44 + apiKey.length
+  val idAtTheSizeLimit: CapiId = {
+    val targetLengthForCapiIdThatIsOnTheLimit = MaxCapiUriLength - expectedUrlSizeWithJustOneSingleCharCapiId + 1
+    val pathWithManySlashesThatWillExpandWhenUrlEncoded = Seq.fill(1000)("a").mkString("/")
+    val remainingChars = targetLengthForCapiIdThatIsOnTheLimit -
+      urlEncodedLengthOf(pathWithManySlashesThatWillExpandWhenUrlEncoded)
+    CapiId(("b" * remainingChars) + pathWithManySlashesThatWillExpandWhenUrlEncoded)
+  }
+  val idThatIsJustOneCharacterOverTheLimit = CapiId("b" + idAtTheSizeLimit.value)
+
+  val practicalRequestSizer = new Practical(client, baseQuery)
+
+  it should "calculate the length of the correct parts of the url - the parts that the length limit applies to" in {
+    practicalRequestSizer.urlLengthFor(Set(CapiId("a"))) shouldEqual expectedUrlSizeWithJustOneSingleCharCapiId
+    practicalRequestSizer.urlLengthFor(Set(idAtTheSizeLimit)) shouldEqual MaxCapiUriLength
+    practicalRequestSizer.urlLengthFor(Set(idThatIsJustOneCharacterOverTheLimit)) shouldEqual MaxCapiUriLength + 1
+
+    val fullUrl = client.url(baseQuery.withIds(Set(idAtTheSizeLimit)))
+    fullUrl.length should be > MaxCapiUriLength // the limit does not include the protocol or domain of the actual url
+  }
+
+  it should "verify the behaviour of the limit on the actual production Content API" in {
+    val testingClient: HttpClient = HttpClient.newBuilder.version(HTTP_2).build()
+    def statusCodeFor(capiId: CapiId): Int = {
+      val fullUrl = client.url(baseQuery.withIds(Set(capiId)))
+      testingClient
+        .send(HttpRequest.newBuilder(URI.create(fullUrl)).GET().build(), discarding)
+        .statusCode
+    }
+
+    statusCodeFor(idAtTheSizeLimit) should not be 414
+    statusCodeFor(idThatIsJustOneCharacterOverTheLimit) shouldBe 414
+  }
+
+  it should "create a verifiable calculator of request size, allowing us to understand how much capacity is taken by the base url" in {
+    val calculated = RequestSizing.Calculated.basedOff(practicalRequestSizer)
+    forAll(sampleIds.subsets().filter(_.nonEmpty).toSeq) { s: Set[CapiId] =>
+      val calcSize = calculated.urlLengthFor(s)
+      val practicalSize = practicalRequestSizer.urlLengthFor(s)
+      calcSize shouldEqual practicalSize
+    }
+  }
+
+  val sampleIds = Set(
+    "us-news/live/2021/jan/19/joe-biden-inauguration-donald-trump-pardons-impeachment-covid-coronavirus-live-updates",
+    "us-news/live/2021/jan/26/joe-biden-donald-trump-impeachment-kamala-harris-nancy-pelosi-covid-coronavirus-live-updates",
+    "us-news/live/2021/jan/13/donald-trump-impeachment-nancy-pelosi-joe-biden-mike-pence-congress-covid-coronavirus-live-updates",
+    "us-news/live/2021/feb/02/donald-trump-impeachment-joe-biden-immigration-covid-coronavirus-live-updates",
+    "us-news/live/2021/feb/22/joe-biden-coronavirus-covid-white-house-texas-donald-trump-live-updates",
+    "us-news/live/2021/feb/08/donald-trump-impeachment-trial-senate-covid-coronavirus-joe-biden-live-updates"
+  ).map(CapiId(_))
+}

--- a/client-cats-effect/src/test/scala/com/gu/contentapi/client/catseffect/bulkqueries/RequestSizingTest.scala
+++ b/client-cats-effect/src/test/scala/com/gu/contentapi/client/catseffect/bulkqueries/RequestSizingTest.scala
@@ -1,0 +1,80 @@
+package com.gu.contentapi.client.catseffect.bulkqueries
+
+import com.gu.contentapi.client.catseffect.bulkqueries.RequestSizing.Calculated.urlEncodedLengthOf
+import com.gu.contentapi.client.catseffect.bulkqueries.RequestSizing.{MaxCapiUriLength, Practical}
+import com.gu.contentapi.client.model.{CapiId, SearchQuery}
+import com.gu.contentapi.client.{ContentApiClient, GuardianContentClient, GuardianContentClientTest}
+import org.scalatest.Inspectors
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+import java.net.URI
+import java.net.http.HttpClient.Version.HTTP_2
+import java.net.http.HttpResponse.BodyHandlers.discarding
+import java.net.http.{HttpClient, HttpRequest}
+
+class RequestSizingTest extends AnyFlatSpec with should.Matchers with Inspectors {
+
+  private val baseQuery: SearchQuery = ContentApiClient.search.lang("en")
+  private val apiKey = GuardianContentClientTest.apiKey
+  private val client: ContentApiClient = new GuardianContentClient(apiKey)
+  private val expectedUrlSizeWithJustOneSingleCharCapiId = 44 + apiKey.length
+  val idAtTheSizeLimit: CapiId = {
+    val targetLengthForCapiIdThatIsOnTheLimit = MaxCapiUriLength - expectedUrlSizeWithJustOneSingleCharCapiId + 1
+    val pathWithManySlashesThatWillExpandWhenUrlEncoded = Seq.fill(1000)("a").mkString("/")
+    val remainingChars = targetLengthForCapiIdThatIsOnTheLimit -
+      urlEncodedLengthOf(pathWithManySlashesThatWillExpandWhenUrlEncoded)
+    CapiId(("b" * remainingChars) + pathWithManySlashesThatWillExpandWhenUrlEncoded)
+  }
+  val idThatIsJustOneCharacterOverTheLimit = CapiId("b" + idAtTheSizeLimit.value)
+
+  val practicalRequestSizer = new Practical(client, baseQuery)
+  val calculatedRequestSizer = RequestSizing.Calculated.basedOff(practicalRequestSizer)
+
+  it should "calculate the length of the correct parts of the url - the parts that the length limit applies to" in {
+    practicalRequestSizer.urlLengthFor(Set(CapiId("a"))) shouldEqual expectedUrlSizeWithJustOneSingleCharCapiId
+    practicalRequestSizer.urlLengthFor(Set(idAtTheSizeLimit)) shouldEqual MaxCapiUriLength
+    practicalRequestSizer.urlLengthFor(Set(idThatIsJustOneCharacterOverTheLimit)) shouldEqual MaxCapiUriLength + 1
+
+    val fullUrl = client.url(baseQuery.withIds(Set(idAtTheSizeLimit)))
+    fullUrl.length should be > MaxCapiUriLength // the limit does not include the protocol or domain of the actual url
+  }
+
+  it should "verify the behaviour of the limit on the actual production Content API" in {
+    val testingClient: HttpClient = HttpClient.newBuilder.version(HTTP_2).build()
+    def statusCodeFor(capiId: CapiId): Int = {
+      val fullUrl = client.url(baseQuery.withIds(Set(capiId)))
+      testingClient
+        .send(HttpRequest.newBuilder(URI.create(fullUrl)).GET().build(), discarding)
+        .statusCode
+    }
+
+    statusCodeFor(idAtTheSizeLimit) should not be 414
+    statusCodeFor(idThatIsJustOneCharacterOverTheLimit) shouldBe 414
+  }
+
+  it should "create a verifiable calculator of request size, allowing us to understand how much capacity is taken by the base url" in {
+
+    forAll(sampleIds.subsets().filter(_.nonEmpty).toSeq) { s: Set[CapiId] =>
+      val calcSize = calculatedRequestSizer.urlLengthFor(s)
+      val practicalSize = practicalRequestSizer.urlLengthFor(s)
+      calcSize shouldEqual practicalSize
+    }
+  }
+
+  it should "match the practical length of fields that contain spaces, as api-gateway IAM auth requires them to be '%20'" in {
+    val s = Set(CapiId("pretty unusual"))
+    val calcSize = calculatedRequestSizer.urlLengthFor(s)
+    val practicalSize = practicalRequestSizer.urlLengthFor(s)
+    calcSize shouldEqual practicalSize
+  }
+
+  val sampleIds = Set(
+    "us-news/live/2021/jan/19/joe-biden-inauguration-donald-trump-pardons-impeachment-covid-coronavirus-live-updates",
+    "us-news/live/2021/jan/26/joe-biden-donald-trump-impeachment-kamala-harris-nancy-pelosi-covid-coronavirus-live-updates",
+    "us-news/live/2021/jan/13/donald-trump-impeachment-nancy-pelosi-joe-biden-mike-pence-congress-covid-coronavirus-live-updates",
+    "us-news/live/2021/feb/02/donald-trump-impeachment-joe-biden-immigration-covid-coronavirus-live-updates",
+    "us-news/live/2021/feb/22/joe-biden-coronavirus-covid-white-house-texas-donald-trump-live-updates",
+    "us-news/live/2021/feb/08/donald-trump-impeachment-trial-senate-covid-coronavirus-joe-biden-live-updates"
+  ).map(CapiId(_))
+}

--- a/client-default/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
+++ b/client-default/src/test/scala/com.gu.contentapi.client/GuardianContentClientTest.scala
@@ -6,16 +6,16 @@ import com.gu.contentapi.client.model.{ContentApiError, FollowingSearchQuery, It
 import com.gu.contentatom.thrift.{AtomData, AtomType}
 import org.scalatest._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
 
 import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 
 object GuardianContentClientTest {
   private final val ApiKeyProperty = "CAPI_TEST_KEY"
-  private val apiKey: String = {
+  val apiKey: String = {
     Option(System.getProperty(ApiKeyProperty)) orElse Option(System.getenv(ApiKeyProperty))
   }.orNull ensuring(_ != null, s"Please supply a $ApiKeyProperty as a system property or an environment variable e.g. sbt -D$ApiKeyProperty=some-api-key")
 }

--- a/client-default/src/test/scala/com.gu.contentapi.client/SampleCapiIds.scala
+++ b/client-default/src/test/scala/com.gu.contentapi.client/SampleCapiIds.scala
@@ -1,0 +1,41 @@
+package com.gu.contentapi.client
+
+import com.gu.contentapi.client.model.CapiId
+
+object SampleCapiIds {
+  val largeSetOfCapiIds: Set[CapiId] = Set(
+    "us-news/live/2021/jan/13/donald-trump-impeachment-nancy-pelosi-joe-biden-mike-pence-congress-covid-coronavirus-live-updates",
+    "us-news/live/2021/feb/02/donald-trump-impeachment-joe-biden-immigration-covid-coronavirus-live-updates",
+    "us-news/live/2021/feb/22/joe-biden-coronavirus-covid-white-house-texas-donald-trump-live-updates",
+    "us-news/live/2021/feb/08/donald-trump-impeachment-trial-senate-covid-coronavirus-joe-biden-live-updates",
+    "us-news/live/2020/nov/24/us-election-donald-trump-joe-biden-coronavirus-covid-19-live-updates",
+    "us-news/live/2021/jan/11/joe-biden-donald-trump-impeachment-capitol-mike-pence-nancy-pelosi-coronavirus-covid-live-updates",
+    "us-news/live/2021/feb/25/joe-biden-kamala-harris-covid-coronavirus-vaccine-donald-trump-cpac-live-updates",
+    "us-news/live/2021/feb/12/donald-trump-impeachment-senate-trial-defense-lwayer-republican-senators-coronavirus-covid-live-updates",
+    "world/ng-interactive/2021/sep/02/covid-19-coronavirus-us-map-latest-cases-state-by-state",
+    "us-news/live/2020/dec/08/us-election-donald-trump-joe-biden-coronavirus-covid-19-live-updates",
+    "us-news/live/2021/feb/16/joe-biden-covid-coronavirus-economy-andrew-cuomo-donald-trump-live-updates",
+    "us-news/live/2021/feb/11/donald-trump-impeachment-senate-trial-live-news-updates",
+    "us-news/live/2020/dec/15/us-election-electoral-college-joe-biden-donald-trump-coronavirus-covid-19-live-updates",
+    "us-news/live/2021/feb/26/joe-biden-democrats-covid-coronavirus-vaccine-minimum-wage-cpac-donald-trump-live-updates",
+    "us-news/live/2021/jan/12/donald-trump-impeachment-insurrection-capitol-joe-biden-coronavirus-covid-live-updates",
+    "us-news/live/2021/jan/28/joe-biden-donald-trump-impeachment-kamala-harris-covid-coronavirus-live-updates",
+    "us-news/live/2020/nov/02/us-election-day-2020-live-updates-president-donald-trump-joe-biden-latest-presidential-election-news-polls-update",
+    "us-news/live/2021/feb/05/joe-biden-donald-trump-impeachment-covid-coronavirus-marjorie-taylor-greene-live-updates",
+    "us-news/live/2020/nov/25/us-election-donald-trump-joe-biden-coronavirus-covid-19-thanksgiving-live-updates",
+    "us-news/live/2021/feb/03/joe-biden-donald-trump-impeachment-covid-coronavirus-republicans-marjorie-taylor-greene-live-updates",
+    "us-news/live/2021/jan/18/joe-biden-inauguration-donald-trump-pardons-washington-impeachment-covid-coronavirus-live",
+    "us-news/live/2021/jan/29/joe-biden-donald-trump-impeachment-covid-coronavirus-nancy-pelosi-kamala-harris-live-updates",
+    "us-news/live/2021/jan/27/joe-biden-donald-trump-impeachment-covid-coronavirus-climate-crisis-executive-orders-live-updates",
+    "us-news/live/2021/jan/25/donald-trump-impeachment-joe-biden-nancy-pelosi-kamal-harris-covid-coronavirus-live-updates",
+    "us-news/live/2021/feb/09/donald-trump-impeachment-senate-trial-live-news-updates",
+    "us-news/live/2021/jan/19/joe-biden-inauguration-donald-trump-pardons-impeachment-covid-coronavirus-live-updates",
+    "us-news/live/2021/feb/04/joe-biden-donald-trump-impeachment-covid-coronavirus-liz-cheney-marjorie-taylor-greene-live-updates",
+    "us-news/live/2021/jan/21/joe-biden-inauguration-administration-kamala-harris-covid-coronavirus-live-updates",
+    "us-news/live/2021/feb/10/donald-trump-impeachment-senate-trial-live-news-updates",
+    "us-news/live/2021/jan/26/joe-biden-donald-trump-impeachment-kamala-harris-nancy-pelosi-covid-coronavirus-live-updates",
+    "us-news/live/2021/jan/22/joe-biden-covid-coronavirus-strategy-donald-trump-impeachment-kamala-harris-live",
+    "us-news/live/2020/nov/05/us-election-joe-biden-donald-trump-result-latest-who-is-winning-live-2020-updates",
+    "us-news/live/2021/feb/01/joe-biden-coronavirus-covid-relief-kamala-harris-donald-trump-impeachment-live-updates"
+  ).map(CapiId(_))
+}

--- a/client/src/main/scala/com.gu.contentapi.client/model/CapiId.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/CapiId.scala
@@ -1,0 +1,6 @@
+package com.gu.contentapi.client.model
+
+case class CapiId(value: String) {
+  require(value.nonEmpty, s"Capi id is empty")
+  require(!value.startsWith("/"), s"Capi id must not start with a forward slash: $value")
+}

--- a/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/model/Queries.scala
@@ -2,6 +2,7 @@ package com.gu.contentapi.client.model
 
 import com.gu.contentapi.client.Decoder.PageableResponseDecoder
 import com.gu.contentapi.client.model.Direction.Next
+import com.gu.contentapi.client.model.SearchQuery.IdSeparator
 import com.gu.contentapi.client.model.v1.{AtomUsageResponse, AtomsResponse, Content, EditionsResponse, ItemResponse, SearchResponse, SectionsResponse, Tag, TagsResponse, VideoStatsResponse}
 import com.gu.contentapi.client.utils.QueryStringParams
 import com.gu.contentapi.client.{Parameter, Parameters}
@@ -91,8 +92,14 @@ case class ItemQuery(id: String, parameterHolder: Map[String, Parameter] = Map.e
   }
 }
 
+object SearchQuery {
+  val IdSeparator = "," // the separator used by the 'ids' parameter
+}
+
 case class SearchQuery(parameterHolder: Map[String, Parameter] = Map.empty, channelId: Option[String] = None)
   extends PaginatedApiQuery[SearchResponse, Content] with SearchQueryBase[SearchQuery] {
+
+  def withIds(capiIds: Set[CapiId]): SearchQuery = ids(capiIds.map(_.value).mkString(IdSeparator))
 
   def setPaginationConsistentWith(response: SearchResponse): PaginatedApiQuery[SearchResponse, Content] =
     pageSize.setIfUndefined(response.pageSize).orderBy.setIfUndefined(response.orderBy)

--- a/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/CapiModelEnrichment.scala
@@ -1,8 +1,8 @@
 package com.gu.contentapi.client.utils
 
+import com.gu.contentapi.client.model.CapiId
 import com.gu.contentapi.client.model.v1._
 import com.gu.contentapi.client.utils.format._
-
 import org.apache.commons.codec.digest.DigestUtils
 
 import java.time.OffsetDateTime
@@ -70,6 +70,8 @@ object CapiModelEnrichment {
   }
 
   implicit class RichContent(val content: Content) extends AnyVal {
+
+    def capiId = CapiId(content.id)
 
     def designType: DesignType = {
 

--- a/client/src/main/scala/com.gu.contentapi.client/utils/QueryStringParams.scala
+++ b/client/src/main/scala/com.gu.contentapi.client/utils/QueryStringParams.scala
@@ -1,19 +1,19 @@
 package com.gu.contentapi.client.utils
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
 
 object QueryStringParams {
-  def apply(parameters: Iterable[(String, String)]) = {
-    /**
-      * api-gateway IAM authorisation requires that spaces are encoded as `%20`, not `+`.
-      * https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
-      */
-    def encodeParameter(p: String): String = URLEncoder.encode(p, "UTF-8").replace("+", "%20")
+  /**
+   * api-gateway IAM authorisation requires that spaces are encoded as `%20`, not `+`.
+   * https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+   */
+  def encodeParameter(p: String): String = URLEncoder.encode(p, UTF_8).replace("+", "%20")
 
+  def apply(parameters: Iterable[(String, String)]) =
     if (parameters.isEmpty) {
       ""
     } else "?" + (parameters map {
       case (k, v) => k + "=" + encodeParameter(v)
     } mkString "&")
-  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,6 @@ object Dependencies {
   val slf4jVersion = "2.0.18"
   val mockitoVersion = "5.12.0"
   val okhttpVersion = "4.12.0"
-  val awsSdkVersion = "1.11.280"
 
   // Note: keep libthrift at a version functionally compatible with that used in content-api-models
   // if build failures occur due to eviction / sbt-assembly mergeStrategy errors

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
 
   val capiModels: ModuleID = "com.gu" %% "content-api-models-scala" % capiModelsVersion
   val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % scalaTestVersion % Test `exclude`("org.mockito", "mockito-core")
-  
+
   // Note: keep libthrift at a version functionally compatible with that used in content-api-models
   // if build failures occur due to eviction / sbt-assembly mergeStrategy errors
   val clientDeps = Seq(


### PR DESCRIPTION
* https://typelevel.org/cats-effect/
* https://fs2.io/

## Features

* **Streaming of paginated results** (`paginatedStream()` using [FS2](https://fs2.io/#/guide) streams) - making it possible to start processing results as they come in, before the pagination of all results has completed.
* **Self rate-limiting** (with `TokenBucket`) - rather than making requests as fast as possible, work out what the per-minute quota is, and then throttle requests as they go out.
* **Safe bulk-requesting of Content** by CAPI id (`BulkContentRequester`) - when requesting an arbitrary number of CAPI-ids, the request url can easily grow larger than the 4096 character url-limit, and get a [`HTTP 414 URI Too Long`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/414) error. This client works out how much url-space is available, and [packs](https://github.com/rtyley/bin-packing) the requested CAPI-ids into the lowest-possible number of requests.


This new Cats Effect client first appeared in [`guardian/word-usage`](https://github.com/guardian/word-usage/blob/7587abcdc06738414655bd05ea5ee4854a4b3925/src/main/scala/com/gu/words/capi/IOCapiClient.scala#L19), and was then used again in https://github.com/guardian/apple-news/pull/714 - to reduce the size of that PR, it makes sense to extract the CAPI-client related code and put it here.

