### PR TITLE
Fix `sbt-dependency-graph.yaml` to support sbt 2

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
       - name: Submit dependencies
         id: submit
-        uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
+        uses: scalacenter/sbt-dependency-submission@d84eef4c09e633bcf5f113bcad7fd5e9af1baee9 # v3.2.3
       - name: Log snapshot for user validation
         id: validate
         run: cat ${{ steps.submit.outputs.snapshot-json-path }} | jq


### PR DESCRIPTION
Like https://github.com/guardian/etag-caching/pull/166, we need to fix this error in `sbt-dependency-graph.yaml` after the merge of https://github.com/guardian/content-api-scala-client/pull/509 (updating us to sbt 2), by updating our version of `sbt-github-dependency-submission` - should have included this change in the first place!

https://github.com/guardian/content-api-scala-client/actions/runs/30928305622/job/92056242170#step:5:18

```
[error] sbt.librarymanagement.ResolveException: Error downloading ch.epfl.scala:sbt-github-dependency-submission_sbt2_3:3.1.0
[error]   Not found
[error]   Not found
[error]   not found: https://repo1.maven.org/maven2/ch/epfl/scala/sbt-github-dependency-submission_sbt2_3/3.1.0/sbt-github-dependency-submission_sbt2_3-3.1.0.pom
[error]   not found: /home/runner/.ivy2/localch.epfl.scala/sbt-github-dependency-submission_sbt2_3/3.1.0/ivys/ivy.xml
```
