### PR TITLE
Re-enable compatibility testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
   .aggregate(client, defaultClient, firehoseClient)
   .settings(
     publish / skip := true,
-    // releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq(
       checkSnapshotDependencies,
       inquireVersions,


### PR DESCRIPTION
Now that PR https://github.com/guardian/content-api-scala-client/pull/516 is merged, and we've released the firehose artifacts with their new bumped-up version number, we can re-enable compatibility testing:

* https://github.com/guardian/gha-scala-library-release-workflow/issues/33

Compat testing would have been confused looking for v49.0.0 of the firehose artifact, as it does not exist!
