### PR TITLE
Re-enable compatibility testing after adding the new Cats Effect CAPI client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
   .aggregate(client, defaultClient, catsEffectClient, firehoseClient)
   .settings(
     publish / skip := true,
-    // releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq(
       checkSnapshotDependencies,
       inquireVersions,


### PR DESCRIPTION
Now that PR https://github.com/guardian/content-api-scala-client/pull/506 is merged, and we've released the new Cats Effect artifacts, we can re-enable compatibility testing:

* https://github.com/guardian/gha-scala-library-release-workflow/issues/33

Compat testing would have been confused looking for prior versions of the Cats Effect artifacts.
